### PR TITLE
fox path to postgres data in docker container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ services:
     image: postgres
     restart: unless-stopped
     volumes:
-      - database:/var/lib/postgresql
+      - database:/var/lib/postgresql/data
     environment:
       POSTGRES_PASSWORD: test
       POSTGRES_USER: bonsai


### PR DESCRIPTION
на моей версии docker-compose при указание пути /var/lib/postgresql и попытки биндинга на хостовую ФС вместо этого, создавался volume который содержал все даные, для решения проблемы необходим путь /var/lib/postgresql/data