### PR TITLE
замена тега postgres с latest на 12,4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
       - postgres
 
   postgres:
-    image: postgres
+    image: postgres:12.4
     restart: unless-stopped
     volumes:
       - database:/var/lib/postgresql/data


### PR DESCRIPTION
образ postgres latest  был обнавлен до версии postgres 13 (docker-library/postgres@9abfeee), который не совместим с 12 версией