### PR TITLE
Add multi-platform docker image for arm64 architecture support

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,26 +4,30 @@ on:
   push:
     branches:
       - 'master'
-      
+
 jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       -
         name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_LOGIN }}
           password: ${{ secrets.DOCKER_TOKEN }}
       -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -  
         name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: impworks/bonsai:latest
           build-args: |
-             BUILD_COMMIT=${{ github.sha }}
+            BUILD_COMMIT=${{ github.sha }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,6 +19,11 @@ jobs:
           username: ${{ secrets.DOCKER_LOGIN }}
           password: ${{ secrets.DOCKER_TOKEN }}
       -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: 'arm64,arm'
+      -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       -  

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM node:14-alpine as node
+FROM --platform=$BUILDPLATFORM node:14-alpine as node
+ARG TARGETARCH
+ARG TARGETVARIANT
+
 WORKDIR /build/Bonsai
 
 ADD src/Bonsai/package.json .
@@ -7,21 +10,39 @@ RUN npm ci
 ADD src/Bonsai .
 RUN node_modules/.bin/gulp build
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0 as net-builder
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0-alpine as net-builder
+ARG TARGETARCH
+ARG TARGETVARIANT
+
 WORKDIR /build
 ADD src/Bonsai.sln .
 ADD src/Bonsai/Bonsai.csproj Bonsai/
 ADD src/Bonsai.Tests.Search/Bonsai.Tests.Search.csproj Bonsai.Tests.Search/
 
-RUN dotnet restore
+RUN --mount=type=cache,id=nuget-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/root/.nuget/packages \
+    dotnet restore -a ${TARGETARCH/amd64/x64}
 COPY --from=node /build .
 
-RUN dotnet publish --output ../out/ --configuration Release --runtime linux-musl-x64 --self-contained true Bonsai/Bonsai.csproj
+RUN --mount=type=cache,id=nuget-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/root/.nuget/packages \
+    dotnet publish Bonsai/Bonsai.csproj \
+      --output ../out/ \
+      --configuration Release \
+      -a ${TARGETARCH/amd64/x64} \
+      --self-contained true
 
-FROM alpine:latest
+FROM --platform=$TARGETPLATFORM alpine:latest
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILD_COMMIT
 
-RUN apk add --no-cache nodejs ffmpeg libintl icu icu-data-full && \
-    apk add --no-cache libgdiplus --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing/
+RUN --mount=type=cache,id=apk-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/var/cache/apk \
+    apk --update add \
+      nodejs \
+      ffmpeg \
+      libintl \
+      icu \
+      icu-data-full \
+    && apk add libgdiplus --repository=https://dl-cdn.alpinelinux.org/alpine/edge/testing/
 
 WORKDIR /app
 COPY --from=net-builder /out .
@@ -32,8 +53,9 @@ RUN ln -s /usr/bin/ffmpeg /app/External/ffmpeg/ffmpeg && \
     ln -s /usr/bin/ffprobe /app/External/ffmpeg/ffprobe && \
     chmod +x /app/Bonsai
 
-ARG BUILD_COMMIT
 ENV ASPNETCORE_ENVIRONMENT=Production
 ENV BuildCommit=$BUILD_COMMIT
+
 EXPOSE 80
+
 ENTRYPOINT ["/app/Bonsai"]


### PR DESCRIPTION
Как описывалось в #181 более нет ограничений в зависимостях от amd64.

Добавил в `Dockerfile` считывание архитектуры и платформы из buildx
Добавил в `Dockerfile` `mount type=cache` для кеширования пакетов и зависимостей (с учетом платформы)
Добавил в github action сборку через buildx (обновил версии)