### PR TITLE
Fix header overflow when website title is too long on mobile

### DIFF
--- a/src/Bonsai/Areas/Common/Styles/Components/mobile.scss
+++ b/src/Bonsai/Areas/Common/Styles/Components/mobile.scss
@@ -27,8 +27,8 @@ $mobile-gap: 10px;
 
         // Logo fills available space, pushing icons to the right
         .logotype {
-            flex-grow: 1;
-            min-width: 0;  // allow flex item to shrink below content size for truncation
+            flex: 1 1 auto;   // override desktop flex-shrink: 0 so the title can shrink
+            min-width: 0;
             padding: 0;
 
             &-image img {

--- a/src/Bonsai/Areas/Common/Styles/Components/mobile.scss
+++ b/src/Bonsai/Areas/Common/Styles/Components/mobile.scss
@@ -28,10 +28,17 @@ $mobile-gap: 10px;
         // Logo fills available space, pushing icons to the right
         .logotype {
             flex-grow: 1;
+            min-width: 0;  // allow flex item to shrink below content size for truncation
             padding: 0;
 
             &-image img {
                 margin-right: 0.5rem;
+            }
+
+            &-text {
+                white-space: nowrap;
+                overflow: hidden;
+                text-overflow: ellipsis;
             }
         }
 


### PR DESCRIPTION
Fixes #335 (reported by @centralhardware).

## Problem

On mobile, a long customized website title caused the search icon and user avatar to be pushed out of view. The `.logotype` flex item lacked a `min-width` constraint, so it could never shrink below its content's intrinsic width regardless of available space.

## Fix

Two changes to the mobile header styles (`mobile.scss`):

- Added `min-width: 0` to `.logotype` — allows the flex item to shrink below its content size
- Added `white-space: nowrap`, `overflow: hidden`, and `text-overflow: ellipsis` to `.logotype-text` — trims the title with `…` when space runs out

The search icon and user avatar now always remain visible on the right side of the header.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ei4iVmJcynfcSmpJqv2sAc)_