### PR TITLE
фон стиля для значка пользователя сливается с белым фонон

### DIFF
--- a/src/Bonsai/Areas/Admin/Views/Users/Index.cshtml
+++ b/src/Bonsai/Areas/Admin/Views/Users/Index.cshtml
@@ -15,7 +15,7 @@
         [UserRole.Unvalidated] = "danger",
         [UserRole.Admin] = "success",
         [UserRole.Editor] = "secondary",
-        [UserRole.User] = "light",
+        [UserRole.User] = "info",
     };
 }
 


### PR DESCRIPTION
старый вариант 
<img width="320" height="492" alt="image" src="https://github.com/user-attachments/assets/cd088201-c2b7-4ac9-a48a-2f20ef55d833" />
новый вариант
<img width="155" height="247" alt="image" src="https://github.com/user-attachments/assets/6c5e36b7-294d-4063-bdb4-f93f1e231f07" />
