### PR TITLE
fix: persist MCP OAuth signing/encryption keys in the database

### DIFF
--- a/src/Bonsai/Areas/Mcp/Logic/Auth/ConfigureOpenIddictServerKeys.cs
+++ b/src/Bonsai/Areas/Mcp/Logic/Auth/ConfigureOpenIddictServerKeys.cs
@@ -1,3 +1,4 @@
+using Bonsai.Data.Models;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
 using OpenIddict.Server;
@@ -14,11 +15,11 @@ public class ConfigureOpenIddictServerKeys(OAuthKeyManager keyManager) : IConfig
     public void Configure(OpenIddictServerOptions options)
     {
         options.SigningCredentials.Add(new SigningCredentials(
-            keyManager.GetSigningKey(),
+            keyManager.GetKey(OAuthKeyPurpose.Signing),
             SecurityAlgorithms.RsaSha256));
 
         options.EncryptionCredentials.Add(new EncryptingCredentials(
-            keyManager.GetEncryptionKey(),
+            keyManager.GetKey(OAuthKeyPurpose.Encryption),
             SecurityAlgorithms.RsaOAEP,
             SecurityAlgorithms.Aes256CbcHmacSha512));
     }

--- a/src/Bonsai/Areas/Mcp/Logic/Auth/ConfigureOpenIddictServerKeys.cs
+++ b/src/Bonsai/Areas/Mcp/Logic/Auth/ConfigureOpenIddictServerKeys.cs
@@ -1,0 +1,25 @@
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+using OpenIddict.Server;
+
+namespace Bonsai.Areas.Mcp.Logic.Auth;
+
+/// <summary>
+/// Registers the persistent signing and encryption credentials on the OpenIddict server options.
+/// This replaces the ephemeral keys that were previously regenerated on every startup, which invalidated
+/// the tokens of already-authorized MCP agents.
+/// </summary>
+public class ConfigureOpenIddictServerKeys(OAuthKeyManager keyManager) : IConfigureOptions<OpenIddictServerOptions>
+{
+    public void Configure(OpenIddictServerOptions options)
+    {
+        options.SigningCredentials.Add(new SigningCredentials(
+            keyManager.GetSigningKey(),
+            SecurityAlgorithms.RsaSha256));
+
+        options.EncryptionCredentials.Add(new EncryptingCredentials(
+            keyManager.GetEncryptionKey(),
+            SecurityAlgorithms.RsaOAEP,
+            SecurityAlgorithms.Aes256CbcHmacSha512));
+    }
+}

--- a/src/Bonsai/Areas/Mcp/Logic/Auth/OAuthKeyManager.cs
+++ b/src/Bonsai/Areas/Mcp/Logic/Auth/OAuthKeyManager.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Threading;
@@ -70,12 +70,8 @@ public class OAuthKeyManager(IServiceScopeFactory scopeFactory)
     {
         var rsa = RSA.Create(2048);
 
-        var existing = db.OAuthKeys.FirstOrDefault(x => x.Purpose == purpose);
-        if (existing != null)
-        {
-            rsa.ImportPkcs8PrivateKey(Convert.FromBase64String(existing.PrivateKey), out _);
+        if (TryImportStoredKey())
             return rsa;
-        }
 
         db.OAuthKeys.Add(new OAuthKey
         {
@@ -92,10 +88,20 @@ public class OAuthKeyManager(IServiceScopeFactory scopeFactory)
         {
             // Another instance generated the key concurrently: discard ours and reuse the stored one.
             db.ChangeTracker.Clear();
-            var stored = db.OAuthKeys.First(x => x.Purpose == purpose);
-            rsa.ImportPkcs8PrivateKey(Convert.FromBase64String(stored.PrivateKey), out _);
+            if (!TryImportStoredKey())
+                throw;
         }
 
         return rsa;
+
+        bool TryImportStoredKey()
+        {
+            var stored = db.OAuthKeys.FirstOrDefault(x => x.Purpose == purpose);
+            if (stored == null)
+                return false;
+
+            rsa.ImportPkcs8PrivateKey(Convert.FromBase64String(stored.PrivateKey), out _);
+            return true;
+        }
     }
 }

--- a/src/Bonsai/Areas/Mcp/Logic/Auth/OAuthKeyManager.cs
+++ b/src/Bonsai/Areas/Mcp/Logic/Auth/OAuthKeyManager.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Threading;
+using Bonsai.Data;
+using Bonsai.Data.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Bonsai.Areas.Mcp.Logic.Auth;
+
+/// <summary>
+/// Loads (or generates and persists) the RSA keys used by the OAuth server to sign and encrypt MCP tokens.
+/// The keys are stored in the database so that already-authorized agents keep their access after a restart
+/// instead of being forced to re-authorize.
+/// </summary>
+public class OAuthKeyManager(IServiceScopeFactory scopeFactory)
+{
+    private const string SigningPurpose = "Signing";
+    private const string EncryptionPurpose = "Encryption";
+
+    private readonly Lock _lock = new();
+    private RsaSecurityKey _signingKey;
+    private RsaSecurityKey _encryptionKey;
+
+    /// <summary>
+    /// Returns the persistent signing key, generating and storing it on first use.
+    /// </summary>
+    public RsaSecurityKey GetSigningKey()
+    {
+        EnsureLoaded();
+        return _signingKey;
+    }
+
+    /// <summary>
+    /// Returns the persistent encryption key, generating and storing it on first use.
+    /// </summary>
+    public RsaSecurityKey GetEncryptionKey()
+    {
+        EnsureLoaded();
+        return _encryptionKey;
+    }
+
+    /// <summary>
+    /// Loads both keys from the database exactly once per process.
+    /// </summary>
+    private void EnsureLoaded()
+    {
+        if (_signingKey != null && _encryptionKey != null)
+            return;
+
+        lock (_lock)
+        {
+            if (_signingKey != null && _encryptionKey != null)
+                return;
+
+            using var scope = scopeFactory.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+            _signingKey = new RsaSecurityKey(LoadOrCreateKey(db, SigningPurpose));
+            _encryptionKey = new RsaSecurityKey(LoadOrCreateKey(db, EncryptionPurpose));
+        }
+    }
+
+    /// <summary>
+    /// Reads the key of the specified purpose from the database, or generates and stores a new one.
+    /// </summary>
+    private static RSA LoadOrCreateKey(AppDbContext db, string purpose)
+    {
+        var rsa = RSA.Create(2048);
+
+        var existing = db.OAuthKeys.FirstOrDefault(x => x.Purpose == purpose);
+        if (existing != null)
+        {
+            rsa.ImportPkcs8PrivateKey(Convert.FromBase64String(existing.PrivateKey), out _);
+            return rsa;
+        }
+
+        db.OAuthKeys.Add(new OAuthKey
+        {
+            Purpose = purpose,
+            PrivateKey = Convert.ToBase64String(rsa.ExportPkcs8PrivateKey()),
+            CreatedAt = DateTimeOffset.UtcNow
+        });
+
+        try
+        {
+            db.SaveChanges();
+        }
+        catch (DbUpdateException)
+        {
+            // Another instance generated the key concurrently: discard ours and reuse the stored one.
+            db.ChangeTracker.Clear();
+            var stored = db.OAuthKeys.First(x => x.Purpose == purpose);
+            rsa.ImportPkcs8PrivateKey(Convert.FromBase64String(stored.PrivateKey), out _);
+        }
+
+        return rsa;
+    }
+}

--- a/src/Bonsai/Areas/Mcp/Logic/Auth/OAuthKeyManager.cs
+++ b/src/Bonsai/Areas/Mcp/Logic/Auth/OAuthKeyManager.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Threading;
@@ -17,56 +18,43 @@ namespace Bonsai.Areas.Mcp.Logic.Auth;
 /// </summary>
 public class OAuthKeyManager(IServiceScopeFactory scopeFactory)
 {
-    private const string SigningPurpose = "Signing";
-    private const string EncryptionPurpose = "Encryption";
-
     private readonly Lock _lock = new();
-    private RsaSecurityKey _signingKey;
-    private RsaSecurityKey _encryptionKey;
+    private Dictionary<OAuthKeyPurpose, RsaSecurityKey> _keys;
 
     /// <summary>
-    /// Returns the persistent signing key, generating and storing it on first use.
+    /// Returns the persistent key of the specified purpose, generating and storing it on first use.
     /// </summary>
-    public RsaSecurityKey GetSigningKey()
+    public RsaSecurityKey GetKey(OAuthKeyPurpose purpose)
     {
         EnsureLoaded();
-        return _signingKey;
+        return _keys[purpose];
     }
 
     /// <summary>
-    /// Returns the persistent encryption key, generating and storing it on first use.
-    /// </summary>
-    public RsaSecurityKey GetEncryptionKey()
-    {
-        EnsureLoaded();
-        return _encryptionKey;
-    }
-
-    /// <summary>
-    /// Loads both keys from the database exactly once per process.
+    /// Loads the keys of all purposes from the database exactly once per process.
     /// </summary>
     private void EnsureLoaded()
     {
-        if (_signingKey != null && _encryptionKey != null)
+        if (_keys != null)
             return;
 
         lock (_lock)
         {
-            if (_signingKey != null && _encryptionKey != null)
+            if (_keys != null)
                 return;
 
             using var scope = scopeFactory.CreateScope();
             var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
 
-            _signingKey = new RsaSecurityKey(LoadOrCreateKey(db, SigningPurpose));
-            _encryptionKey = new RsaSecurityKey(LoadOrCreateKey(db, EncryptionPurpose));
+            _keys = Enum.GetValues<OAuthKeyPurpose>()
+                        .ToDictionary(x => x, x => new RsaSecurityKey(LoadOrCreateKey(db, x)));
         }
     }
 
     /// <summary>
     /// Reads the key of the specified purpose from the database, or generates and stores a new one.
     /// </summary>
-    private static RSA LoadOrCreateKey(AppDbContext db, string purpose)
+    private static RSA LoadOrCreateKey(AppDbContext db, OAuthKeyPurpose purpose)
     {
         var rsa = RSA.Create(2048);
 

--- a/src/Bonsai/Code/Config/Startup.Mcp.cs
+++ b/src/Bonsai/Code/Config/Startup.Mcp.cs
@@ -84,17 +84,6 @@ public partial class Startup
                     "mcp"  // Custom scope for MCP access
                 );
 
-                // In development, use the framework's development certificates, which are persisted
-                // in the current user's profile and therefore survive restarts.
-                // In production, persistent RSA keys are loaded from (or generated into) the database
-                // by ConfigureOpenIddictServerKeys, so that tokens issued to already-authorized MCP
-                // agents remain valid across restarts instead of being invalidated by a fresh key.
-                if (Environment.EnvironmentName == "Development")
-                {
-                    options.AddDevelopmentEncryptionCertificate()
-                        .AddDevelopmentSigningCertificate();
-                }
-
                 // Disable access token encryption for easier debugging
                 // MCP clients expect plain JWT tokens
                 options.DisableAccessTokenEncryption();
@@ -137,13 +126,10 @@ public partial class Startup
                 options.UseAspNetCore();
             });
 
-        // In production, supply the server's signing/encryption credentials from persistent keys
-        // stored in the database (development relies on the framework's development certificates).
-        if (Environment.EnvironmentName != "Development")
-        {
-            services.AddSingleton<OAuthKeyManager>();
-            services.AddSingleton<IConfigureOptions<OpenIddictServerOptions>, ConfigureOpenIddictServerKeys>();
-        }
+        // Supply the server's signing/encryption credentials from persistent keys
+        // stored in the database.
+        services.AddSingleton<OAuthKeyManager>();
+        services.AddSingleton<IConfigureOptions<OpenIddictServerOptions>, ConfigureOpenIddictServerKeys>();
     }
 
     /// <summary>

--- a/src/Bonsai/Code/Config/Startup.Mcp.cs
+++ b/src/Bonsai/Code/Config/Startup.Mcp.cs
@@ -5,6 +5,7 @@ using Bonsai.Areas.Mcp.Logic.Auth;
 using Bonsai.Areas.Mcp.Logic.Services;
 using Bonsai.Data;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using OpenIddict.Abstractions;
 using OpenIddict.Server;
 
@@ -83,18 +84,15 @@ public partial class Startup
                     "mcp"  // Custom scope for MCP access
                 );
 
-                // Use development encryption/signing keys in development
-                // In production, you should use proper certificates
+                // In development, use the framework's development certificates, which are persisted
+                // in the current user's profile and therefore survive restarts.
+                // In production, persistent RSA keys are loaded from (or generated into) the database
+                // by ConfigureOpenIddictServerKeys, so that tokens issued to already-authorized MCP
+                // agents remain valid across restarts instead of being invalidated by a fresh key.
                 if (Environment.EnvironmentName == "Development")
                 {
                     options.AddDevelopmentEncryptionCertificate()
                         .AddDevelopmentSigningCertificate();
-                }
-                else
-                {
-                    // For production, use ephemeral keys (you should configure proper certificates)
-                    options.AddEphemeralEncryptionKey()
-                        .AddEphemeralSigningKey();
                 }
 
                 // Disable access token encryption for easier debugging
@@ -138,6 +136,14 @@ public partial class Startup
                 // Register the ASP.NET Core host
                 options.UseAspNetCore();
             });
+
+        // In production, supply the server's signing/encryption credentials from persistent keys
+        // stored in the database (development relies on the framework's development certificates).
+        if (Environment.EnvironmentName != "Development")
+        {
+            services.AddSingleton<OAuthKeyManager>();
+            services.AddSingleton<IConfigureOptions<OpenIddictServerOptions>, ConfigureOpenIddictServerKeys>();
+        }
     }
 
     /// <summary>

--- a/src/Bonsai/Data/AppDbContext.cs
+++ b/src/Bonsai/Data/AppDbContext.cs
@@ -21,6 +21,7 @@ public class AppDbContext : IdentityDbContext<AppUser>
     }
 
     public virtual DbSet<DynamicConfigWrapper> DynamicConfig => Set<DynamicConfigWrapper>();
+    public virtual DbSet<OAuthKey> OAuthKeys => Set<OAuthKey>();
     public virtual DbSet<Changeset> Changes => Set<Changeset>();
     public virtual DbSet<ChangeEventGroup> ChangeEvents => Set<ChangeEventGroup>();
     public virtual DbSet<LivingBeingOverview> LivingBeingOverviews => Set<LivingBeingOverview>();

--- a/src/Bonsai/Data/Migrations/20260714183147_OAuthKeys.Designer.cs
+++ b/src/Bonsai/Data/Migrations/20260714183147_OAuthKeys.Designer.cs
@@ -357,9 +357,8 @@ namespace Bonsai.Data.Migrations
 
             modelBuilder.Entity("Bonsai.Data.Models.OAuthKey", b =>
                 {
-                    b.Property<string>("Purpose")
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
+                    b.Property<int>("Purpose")
+                        .HasColumnType("integer");
 
                     b.Property<DateTimeOffset>("CreatedAt")
                         .HasColumnType("timestamp with time zone");

--- a/src/Bonsai/Data/Migrations/20260714183147_OAuthKeys.Designer.cs
+++ b/src/Bonsai/Data/Migrations/20260714183147_OAuthKeys.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Bonsai.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Bonsai.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260714183147_OAuthKeys")]
+    partial class OAuthKeys
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Bonsai/Data/Migrations/20260714183147_OAuthKeys.cs
+++ b/src/Bonsai/Data/Migrations/20260714183147_OAuthKeys.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Bonsai.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class OAuthKeys : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "OAuthKeys",
+                columns: table => new
+                {
+                    Purpose = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    PrivateKey = table.Column<string>(type: "text", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OAuthKeys", x => x.Purpose);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "OAuthKeys");
+        }
+    }
+}

--- a/src/Bonsai/Data/Migrations/20260714183147_OAuthKeys.cs
+++ b/src/Bonsai/Data/Migrations/20260714183147_OAuthKeys.cs
@@ -15,7 +15,7 @@ namespace Bonsai.Data.Migrations
                 name: "OAuthKeys",
                 columns: table => new
                 {
-                    Purpose = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    Purpose = table.Column<int>(type: "integer", nullable: false),
                     PrivateKey = table.Column<string>(type: "text", nullable: false),
                     CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
                 },

--- a/src/Bonsai/Data/Migrations/AppDbContextModelSnapshot.cs
+++ b/src/Bonsai/Data/Migrations/AppDbContextModelSnapshot.cs
@@ -354,9 +354,8 @@ namespace Bonsai.Data.Migrations
 
             modelBuilder.Entity("Bonsai.Data.Models.OAuthKey", b =>
                 {
-                    b.Property<string>("Purpose")
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
+                    b.Property<int>("Purpose")
+                        .HasColumnType("integer");
 
                     b.Property<DateTimeOffset>("CreatedAt")
                         .HasColumnType("timestamp with time zone");

--- a/src/Bonsai/Data/Models/OAuthKey.cs
+++ b/src/Bonsai/Data/Models/OAuthKey.cs
@@ -11,11 +11,10 @@ namespace Bonsai.Data.Models;
 public class OAuthKey
 {
     /// <summary>
-    /// Purpose of the key: <c>Signing</c> or <c>Encryption</c>.
+    /// Purpose of the key: signing or encryption.
     /// </summary>
     [Key]
-    [StringLength(50)]
-    public string Purpose { get; set; }
+    public OAuthKeyPurpose Purpose { get; set; }
 
     /// <summary>
     /// Base64-encoded PKCS#8 RSA private key.

--- a/src/Bonsai/Data/Models/OAuthKey.cs
+++ b/src/Bonsai/Data/Models/OAuthKey.cs
@@ -1,0 +1,30 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace Bonsai.Data.Models;
+
+/// <summary>
+/// A cryptographic key used by the OAuth server (OpenIddict) to sign and encrypt MCP access tokens.
+/// Persisted in the database so that tokens issued to authorized agents remain valid across application
+/// restarts (otherwise a new key would be generated on every startup and force agents to re-authorize).
+/// </summary>
+public class OAuthKey
+{
+    /// <summary>
+    /// Purpose of the key: <c>Signing</c> or <c>Encryption</c>.
+    /// </summary>
+    [Key]
+    [StringLength(50)]
+    public string Purpose { get; set; }
+
+    /// <summary>
+    /// Base64-encoded PKCS#8 RSA private key.
+    /// </summary>
+    [Required]
+    public string PrivateKey { get; set; }
+
+    /// <summary>
+    /// Timestamp when the key was generated.
+    /// </summary>
+    public DateTimeOffset CreatedAt { get; set; }
+}

--- a/src/Bonsai/Data/Models/OAuthKeyPurpose.cs
+++ b/src/Bonsai/Data/Models/OAuthKeyPurpose.cs
@@ -1,0 +1,17 @@
+namespace Bonsai.Data.Models;
+
+/// <summary>
+/// Purpose of a cryptographic key used by the OAuth server.
+/// </summary>
+public enum OAuthKeyPurpose
+{
+    /// <summary>
+    /// Key for signing MCP tokens.
+    /// </summary>
+    Signing,
+
+    /// <summary>
+    /// Key for encrypting MCP tokens.
+    /// </summary>
+    Encryption
+}


### PR DESCRIPTION
В production среде сервер OpenIddict использовал временные ключи подписи и шифрования, которые генерировались заново при каждом запуске. 

Теперь ключи генерируются один раз и хранятся в базе данных (таблица OAuthKeys), а затем загружаются при последующих запусках, так что выданные токены остаются действительными при перезапусках.

Разработка по-прежнему опирается на сертификаты разработки фреймворка, которые уже сохраняются для каждого пользователя.

Closes #344.