### PR TITLE
Рендерер для дерева на основе Graphviz

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ ARG BUILD_COMMIT
 
 RUN --mount=type=cache,id=apk-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/var/cache/apk \
     apk --update add \
-      nodejs \
+      graphviz \
       ffmpeg \
       libintl \
       icu \
@@ -50,7 +50,7 @@ WORKDIR /app
 COPY --from=net-builder /out .
 
 RUN mkdir /app/App_Data && chmod +w /app/App_Data
-RUN mkdir /app/External/ffmpeg
+RUN mkdir -p /app/External/ffmpeg
 RUN ln -s /usr/bin/ffmpeg /app/External/ffmpeg/ffmpeg && \
     ln -s /usr/bin/ffprobe /app/External/ffmpeg/ffprobe && \
     chmod +x /app/Bonsai

--- a/Dockerfile.lite
+++ b/Dockerfile.lite
@@ -27,7 +27,7 @@ FROM alpine:latest
 ARG BUILD_COMMIT
 
 RUN apk --update add \
-      nodejs \
+      graphviz \
       ffmpeg \
       libintl \
       icu \
@@ -40,7 +40,7 @@ WORKDIR /app
 COPY --from=net-builder /out .
 
 RUN mkdir /app/App_Data && chmod +w /app/App_Data
-RUN mkdir /app/External/ffmpeg
+RUN mkdir -p /app/External/ffmpeg
 RUN ln -s /usr/bin/ffmpeg /app/External/ffmpeg/ffmpeg && \
     ln -s /usr/bin/ffprobe /app/External/ffmpeg/ffprobe && \
     chmod +x /app/Bonsai

--- a/README.en.md
+++ b/README.en.md
@@ -66,8 +66,9 @@ For development, you will need the following:
 * [.NET 10](https://dotnet.microsoft.com/en-us/download/dotnet/10.0): the main runtime for Bonsai
 
 1. Install [NodeJS](https://nodejs.org/en/)
-2. Download [ffmpeg shared binaries](https://www.ffmpeg.org/download.html) for your system and extract the archive's contents into `External/ffmpeg` folder in the solution root (must contain both `ffmpeg` and `ffprobe` executables).
-3. Create a file called `appsettings.Development.json`, add the connection string:
+2. Install [Graphviz](https://graphviz.org/download/) and extract the `bin` folder into the `External/graphviz` folder in the solution root (must contain `dot`).
+3. Download [ffmpeg shared binaries](https://www.ffmpeg.org/download.html) and extract the archive's contents into `External/ffmpeg` folder in the solution root (must contain both `ffmpeg` and `ffprobe` executables).
+4. Create a file called `appsettings.Development.json`, add the connection string:
 
     ```
     {

--- a/README.md
+++ b/README.md
@@ -68,8 +68,9 @@
 * [.NET 10](https://dotnet.microsoft.com/download/dotnet/10.0): основной рантайм для Bonsai
 
 1. Установите [NodeJS](https://nodejs.org/en/)
-2. Скачайте [shared-сборку ffmpeg](https://www.ffmpeg.org/download.html) для вашей операционной системы и извлеките данные в папку `External/ffmpeg` в корне проекта (необходимы исполняемые файлы `ffmpeg` и `ffprobe`).
-3. Создайте файл `appsettings.Development.json`, пропишите строку подключения к БД:
+2. Установите [Graphviz](https://graphviz.org/download/), извлеките данные из папки `bin` в папку `External/graphviz` в корне проекта (необходим файл `dot`).
+3. Скачайте [shared-сборку ffmpeg](https://www.ffmpeg.org/download.html) и извлеките данные в папку `External/ffmpeg` в корне проекта (необходимы исполняемые файлы `ffmpeg` и `ffprobe`).
+4. Создайте файл `appsettings.Development.json`, пропишите строку подключения к БД:
 
   ```
     {

--- a/src/Bonsai/Areas/Admin/BackendScripts/tree-layout.js
+++ b/src/Bonsai/Areas/Admin/BackendScripts/tree-layout.js
@@ -1,133 +1,1186 @@
-﻿var ELK = require('./elk.js');
+var Viz = require('./viz.cjs');
 
-module.exports = function(callback, jsonIn, thoroughness) {
-    var data = JSON.parse(jsonIn);
-    var elkJson = generateElkJson(data, thoroughness);
-    var elk = new ELK();
+var SPACING = 30,         // margin around the whole canvas
+    RANKSEP = 0.75,       // dot units (inches); 0.42 starts producing crossings
+    NODESEP = 0.56;
 
-    elk.layout(elkJson)
-       .then(function (result) {
-            var jsonOut = JSON.stringify(result);
-            callback(null, jsonOut);
-       }, function (err) {
-            callback(err, null);
-       });
+// The card geometry of the two views. Everything about a row is measured in
+// these numbers, so switching the view is a matter of setting them before the
+// layout runs: dot gets smaller nodes and every gap expressed in card terms
+// follows along. The compact card is half as wide, a little shorter, and keeps
+// its couple gap and marriage ports in proportion to that.
+var VIEWS = {
+    Default: { cardWidth: 300, cardHeight: 100, coupleGap: 60, portInset: 40 },
+    Compact: { cardWidth: 150, cardHeight: 76, coupleGap: 30, portInset: 20 }
 };
 
-function generateElkJson(data, thoroughness) {
-    var CARD_WIDTH = 300,
-        CARD_HEIGHT = 100,
-        SPACING = 30;
+var CARD_WIDTH,           // card box, as the front-end will render it
+    CARD_HEIGHT,
+    COUPLE_GAP,           // gap between two spouses inside one family block
+    PORT_INSET;           // keeps the marriage ports off the card corners
 
-    // converts Bonsai-style JSON to ELK-style
-    var nodes = [];
-    var edges = [];
+applyView('Default');
 
-    processPersons();
-    processRelations();
+// The vertical band between two rows of cards, and how the wires divide it up.
+// All three horizontal runs that live in the band - the marriage brackets, the
+// sibling buses, and the lanes a trunk steps into to get past a row - need room
+// of their own, otherwise they collapse into one another and read as noise.
+var ROW_GAP = Math.round(RANKSEP * 72),
+    UNION_DROP = Math.round(ROW_GAP / 3),   // card bottom -> union point
+    BUS_RISE = Math.round(ROW_GAP / 3),     // sibling bus -> child row top
+    CARD_CLEARANCE = 20;                    // sideways room when dodging a card
 
-    return {
+// A row wants two different minimum gaps, and dot's nodesep is a single number
+// for the whole graph. So dot lays the row out at the tight one and spread()
+// opens up the pairs that deserve the wide one.
+var KIN_GAP = Math.round(NODESEP * 72),     // between siblings: keep the group tight
+    STRANGER_GAP = KIN_GAP * 2;             // between families with no sibling link
+
+// dot's result depends on the order the nodes and edges are declared in, and the
+// spread between a lucky and an unlucky order is large (25% on total edge length
+// on the reference tree). So the layout is run many times over shuffled orders
+// and the best-scoring one is kept.
+// This only pays off for the full tree: the partial trees (ancestors, descendants,
+// close family) are narrow and near-hierarchical, dot gets them right on the first
+// order, and they are rendered once per page - so they run a single attempt.
+var MIN_ATTEMPTS = 8,       // always try at least this many orders
+    MAX_ATTEMPTS = 400,
+    BUDGET_MS = 2000,      // stop shuffling once this much time has been spent
+    COMPACT_PASSES = 24,    // sweeps of the slide-into-the-slack pass
+    WIDTH_WEIGHT = 8;     // px of edge length one px of extra width is worth
+
+var vizPromise = null;
+
+/**
+ * Calculates the layout of a tree.
+ * The second argument used to be the ELK thoroughness; it now tells the layout
+ * whether to search over many declaration orders (full tree) or to take dot's
+ * first result as it comes (partial trees).
+ * The third one carries the display settings: { direction, view }, matching the
+ * TreeDirection and TreeViewMode names on the backend. Both are optional and
+ * fall back to a top-to-bottom tree of default-sized cards.
+ */
+module.exports = function (callback, jsonIn, exhaustive, options) {
+    try {
+        if (vizPromise === null)
+            vizPromise = Viz.instance();
+
+        vizPromise.then(function (viz) {
+            try {
+                var data = JSON.parse(jsonIn);
+                callback(null, JSON.stringify(layout(viz, data, exhaustive !== false, options)));
+            } catch (err) {
+                callback(err, null);
+            }
+        }, function (err) {
+            vizPromise = null;      // allow a retry on the next invocation
+            callback(err, null);
+        });
+    } catch (err) {
+        callback(err, null);
+    }
+};
+
+// ---------------------------------------------------------------- layout
+
+function layout(viz, data, exhaustive, options) {
+    var opts = options || {};
+    applyView(opts.view);
+
+    var persons = canonicalPersons(data.Persons || [], data.Relations || []);
+    var relations = (data.Relations || []).slice().sort(function (a, b) {
+        return a.Id < b.Id ? -1 : a.Id > b.Id ? 1 : 0;
+    });
+
+    var blocks = buildBlocks(persons, relations);
+    var ctx = buildContext(persons, relations, blocks);
+
+    var best = search(viz, persons, relations, blocks, ctx, exhaustive);
+    var pos = best.pos;
+
+    normalize(pos);
+    alignUnions(pos, relations, ctx);
+
+    var bands = buildBands(pos, persons);
+    var edges = routeEdges(persons, relations, pos, bands);
+    var size = measure(pos);
+
+    var tree = {
         id: 'root',
-        layoutOptions: {
-            'elk.algorithm': 'layered',
-            'elk.direction': 'DOWN',
-            'elk.edgeRouting': 'ORTHOGONAL',
-            'elk.layered.spacing.edgeEdgeBetweenLayers': SPACING,
-            'elk.layered.spacing.edgeNodeBetweenLayers': SPACING,
-            'elk.spacing.nodeNode': SPACING,
-            'elk.layered.nodePlacement.favorStraightEdges': false,
-            'elk.layered.thoroughness': thoroughness
-        },
-        children: nodes,
+        width: size.width,
+        height: size.height,
+        children: buildChildren(persons, relations, pos),
         edges: edges
     };
 
-    function processPersons() {
-        // registers person cards
-        for (var i = 0; i < data.Persons.length; i++) {
-            var person = data.Persons[i];
-            nodes.push({
-                id: person.Id,
-                label: person.Name,
-                width: CARD_WIDTH,
-                height: CARD_HEIGHT,
-                info: person,
-                layoutOptions: {
-                    'elk.portConstraints': 'FIXED_SIDE'
-                },
-                ports: [
-                    {
-                        id: person.Id + ":n",
-                        layoutOptions: {
-                            'elk.port.side': 'NORTH'
-                        }
-                    },
-                    {
-                        id: person.Id + ":s",
-                        layoutOptions: {
-                            'elk.port.side': 'SOUTH'
-                        }
-                    }
-                ]
-            });
+    if (isBottomToTop(opts.direction))
+        flipVertical(tree);
 
-            if (person.Parents !== null) {
-                edges.push({
-                    id: person.Id + ':' + person.Parents,
-                    sources: [person.Parents + ':s'],
-                    targets: [person.Id + ':n'],
-                    info: {
-                        fakeTarget: false
-                    }
-                });
+    return tree;
+}
+
+/** Sets the card geometry for the requested view. Unknown names get the default. */
+function applyView(view) {
+    var v = VIEWS[view] || VIEWS.Default;
+    CARD_WIDTH = v.cardWidth;
+    CARD_HEIGHT = v.cardHeight;
+    COUPLE_GAP = v.coupleGap;
+    PORT_INSET = v.portInset;
+}
+
+function isBottomToTop(direction) {
+    return direction === 'BottomToTop';
+}
+
+/**
+ * Mirrors the finished layout around the horizontal axis of the canvas.
+ *
+ * The whole layout is built top-down - dot ranks parents above children, the
+ * marriage brackets hang below the cards, the sibling buses run above them - so
+ * bottom-to-top is a mirror of the finished geometry rather than a second layout
+ * mode. Every wire is orthogonal, so mirroring leaves the corners square, and
+ * the cards themselves are only moved, never turned over.
+ */
+function flipVertical(tree) {
+    var i, j;
+
+    for (i = 0; i < tree.children.length; i++) {
+        var c = tree.children[i];
+        c.y = tree.height - (c.y + c.height);
+    }
+
+    for (i = 0; i < tree.edges.length; i++) {
+        var s = tree.edges[i].sections[0];
+        s.startPoint.y = tree.height - s.startPoint.y;
+        s.endPoint.y = tree.height - s.endPoint.y;
+        for (j = 0; j < s.bendPoints.length; j++)
+            s.bendPoints[j].y = tree.height - s.bendPoints[j].y;
+    }
+}
+
+/**
+ * Sorts the persons into an order that does not depend on the ids.
+ *
+ * The backend invents a fresh random Guid for every "unknown spouse" placeholder
+ * on every run, so an id-derived order makes the layout differ from run to run
+ * for no reason. Sorting by name plus the surrounding names pins it down.
+ */
+function canonicalPersons(persons, relations) {
+    var spouses = {}, kids = {}, i;
+    var name = {};
+
+    for (i = 0; i < persons.length; i++) name[persons[i].Id] = persons[i].Name || '';
+
+    for (i = 0; i < relations.length; i++) {
+        var r = relations[i];
+        (spouses[r.From] || (spouses[r.From] = [])).push(name[r.To] || '');
+        (spouses[r.To] || (spouses[r.To] = [])).push(name[r.From] || '');
+    }
+    for (i = 0; i < persons.length; i++) {
+        var p = persons[i];
+        if (p.Parents) (kids[p.Parents] || (kids[p.Parents] = [])).push(p.Name || '');
+    }
+
+    var keyed = [];
+    for (i = 0; i < persons.length; i++) {
+        var person = persons[i];
+        var own = (spouses[person.Id] || []).slice().sort().join(',');
+        var below = [];
+        for (var j = 0; j < relations.length; j++) {
+            var rel = relations[j];
+            if (rel.From === person.Id || rel.To === person.Id)
+                below = below.concat(kids[rel.Id] || []);
+        }
+        keyed.push({
+            p: person,
+            key: [person.Name || '', person.Parents || '', own, below.sort().join(',')].join(''),
+            i: i
+        });
+    }
+
+    keyed.sort(function (a, b) {
+        if (a.key !== b.key) return a.key < b.key ? -1 : 1;
+        return a.i - b.i;
+    });
+
+    var out = [];
+    for (i = 0; i < keyed.length; i++) out.push(keyed[i].p);
+    return out;
+}
+
+// ---------------------------------------------------------------- family blocks
+
+/**
+ * Merges every couple into a single wide node. dot's crossing minimisation has
+ * no notion of "keep these two nodes adjacent", so without this a stranger's
+ * card can end up wedged between two spouses.
+ */
+function buildBlocks(persons, relations) {
+    var parent = {};
+    var i;
+
+    for (i = 0; i < persons.length; i++)
+        parent[persons[i].Id] = persons[i].Id;
+
+    function find(x) {
+        while (parent[x] !== x) {
+            parent[x] = parent[parent[x]];
+            x = parent[x];
+        }
+        return x;
+    }
+
+    for (i = 0; i < relations.length; i++) {
+        var rel = relations[i];
+        if (parent[rel.From] === undefined || parent[rel.To] === undefined)
+            continue;
+        var ra = find(rel.From), rb = find(rel.To);
+        if (ra !== rb) parent[ra] = rb;
+    }
+
+    var byRoot = {};
+    var list = [];
+    var blockOf = {};
+    for (i = 0; i < persons.length; i++) {
+        var root = find(persons[i].Id);
+        if (!byRoot[root]) {
+            byRoot[root] = { id: root, name: 'b' + list.length, members: [], relations: [] };
+            list.push(byRoot[root]);
+        }
+        byRoot[root].members.push(persons[i].Id);
+        blockOf[persons[i].Id] = root;
+    }
+    for (i = 0; i < relations.length; i++) {
+        var b = byRoot[find(relations[i].From)];
+        if (b) b.relations.push(relations[i]);
+    }
+
+    var byName = {};
+    for (i = 0; i < list.length; i++) {
+        var block = list[i];
+        block.members = chainMembers(block.members, block.relations);
+        block.width = block.members.length * CARD_WIDTH + (block.members.length - 1) * COUPLE_GAP;
+        block.orders = memberOrders(block);
+        byName[block.name] = block;
+    }
+
+    return { list: list, byId: byRoot, byName: byName, blockOf: blockOf };
+}
+
+/** Orders a block's members along the marriage chain, so spouses touch. */
+function chainMembers(members, relations) {
+    if (members.length < 2) return members;
+
+    var adj = {};
+    var i;
+    for (i = 0; i < members.length; i++) adj[members[i]] = [];
+    for (i = 0; i < relations.length; i++) {
+        var r = relations[i];
+        if (adj[r.From] && adj[r.To]) {
+            adj[r.From].push(r.To);
+            adj[r.To].push(r.From);
+        }
+    }
+
+    var start = members[0];
+    for (i = 0; i < members.length; i++) {
+        if (adj[members[i]].length === 1) { start = members[i]; break; }
+    }
+
+    var seen = {}, order = [], stack = [start];
+    while (stack.length) {
+        var id = stack.pop();
+        if (seen[id]) continue;
+        seen[id] = true;
+        order.push(id);
+        var next = adj[id];
+        for (i = next.length - 1; i >= 0; i--)
+            if (!seen[next[i]]) stack.push(next[i]);
+    }
+    for (i = 0; i < members.length; i++)
+        if (!seen[members[i]]) order.push(members[i]);
+
+    return order;
+}
+
+/**
+ * The candidate left-to-right arrangements of one block's cards.
+ *
+ * Which spouse stands on which side is free, and picking the wrong side leaves a
+ * long diagonal run to the parents. Small blocks get every permutation that
+ * keeps married pairs touching; larger ones just get the chain and its mirror.
+ */
+function memberOrders(block) {
+    var members = block.members;
+    if (members.length < 2) return [members];
+    if (members.length > 4)
+        return [members, members.slice().reverse()];
+
+    var married = {};
+    var i;
+    for (i = 0; i < block.relations.length; i++) {
+        var r = block.relations[i];
+        married[r.From + ' ' + r.To] = true;
+        married[r.To + ' ' + r.From] = true;
+    }
+
+    var best = [], bestPairs = -1;
+    permute(members, function (order) {
+        var pairs = 0;
+        for (var j = 1; j < order.length; j++)
+            if (married[order[j - 1] + ' ' + order[j]]) pairs++;
+        if (pairs > bestPairs) { bestPairs = pairs; best = [order]; }
+        else if (pairs === bestPairs) best.push(order);
+    });
+
+    return best;
+}
+
+function permute(items, fn) {
+    var out = [];
+    (function step(rest, acc) {
+        if (!rest.length) { fn(acc.slice()); return; }
+        for (var i = 0; i < rest.length; i++) {
+            acc.push(rest[i]);
+            step(rest.slice(0, i).concat(rest.slice(i + 1)), acc);
+            acc.pop();
+        }
+    })(items, out);
+}
+
+// ---------------------------------------------------------------- context
+
+/** Precomputes the parent/child wiring the scorer needs, in block terms. */
+function buildContext(persons, relations, blocks) {
+    var relById = {}, i;
+    for (i = 0; i < relations.length; i++) relById[relations[i].Id] = relations[i];
+
+    // block -> block links, one per distinct pair, as dot sees them
+    var links = [], seen = {};
+    // union -> children, and union -> spouses, as the scorer sees them
+    var kids = {};
+
+    for (i = 0; i < persons.length; i++) {
+        var person = persons[i];
+        if (!person.Parents) continue;
+        var rel = relById[person.Parents];
+        if (!rel) continue;
+
+        (kids[rel.Id] || (kids[rel.Id] = [])).push(person.Id);
+
+        var from = blocks.blockOf[rel.From] || blocks.blockOf[rel.To];
+        var to = blocks.blockOf[person.Id];
+        if (!from || !to || from === to) continue;
+
+        var key = from + ' ' + to;
+        if (seen[key]) continue;    // dot only needs the family link once
+        seen[key] = true;
+        links.push({ from: blocks.byId[from].name, to: blocks.byId[to].name });
+    }
+
+    var ctx = { links: links, kids: kids, relById: relById };
+    ctx.kin = buildKin(relations, ctx, blocks);
+    return ctx;
+}
+
+/**
+ * The pairs of blocks that may stand close together.
+ *
+ * Siblings read as one group and should stay tight; two families with no such
+ * link should be visibly apart. Gathering the children per *person* rather than
+ * per union means half-siblings, who share only one parent, count as kin too.
+ */
+function buildKin(relations, ctx, blocks) {
+    var byPerson = {}, i, j, k;
+
+    function add(personId, name) {
+        if (!byPerson[personId]) byPerson[personId] = [];
+        byPerson[personId].push(name);
+    }
+
+    for (i = 0; i < relations.length; i++) {
+        var rel = relations[i];
+        var kids = ctx.kids[rel.Id] || [];
+        for (j = 0; j < kids.length; j++) {
+            var root = blocks.blockOf[kids[j]];
+            if (!root) continue;
+            var name = blocks.byId[root].name;
+            add(rel.From, name);
+            add(rel.To, name);
+        }
+    }
+
+    var kin = {};
+    for (var personId in byPerson) {
+        if (!Object.prototype.hasOwnProperty.call(byPerson, personId)) continue;
+        var list = byPerson[personId];
+        for (j = 0; j < list.length; j++)
+            for (k = j + 1; k < list.length; k++)
+                if (list[j] !== list[k]) kin[pairKey(list[j], list[k])] = true;
+    }
+    return kin;
+}
+
+function pairKey(a, b) {
+    return a < b ? a + ' ' + b : b + ' ' + a;
+}
+
+/** The minimum gap the row must leave between two neighbouring blocks. */
+function gapBetween(kin, a, b) {
+    return kin[pairKey(a.name, b.name)] ? KIN_GAP : STRANGER_GAP;
+}
+
+// ---------------------------------------------------------------- dot source
+
+function buildDot(blocks, ctx, blockOrder, linkOrder) {
+    var lines = ['digraph G {'];
+    lines.push('  graph [rankdir=TB, ranksep="' + RANKSEP + '", nodesep="' + NODESEP + '"];');
+    lines.push('  node [shape=box, fixedsize=true, height="' + (CARD_HEIGHT / 72) + '", label=""];');
+    lines.push('  edge [arrowhead=none];');
+
+    var i;
+    for (i = 0; i < blockOrder.length; i++) {
+        var b = blocks.list[blockOrder[i]];
+        lines.push('  ' + b.name + ' [width="' + (b.width / 72) + '"];');
+    }
+
+    for (i = 0; i < linkOrder.length; i++) {
+        var link = ctx.links[linkOrder[i]];
+        lines.push('  ' + link.from + ' -> ' + link.to + ';');
+    }
+
+    lines.push('}');
+    return lines.join('\n');
+}
+
+// ---------------------------------------------------------------- search
+
+function mulberry32(seed) {
+    var a = seed >>> 0;
+    return function () {
+        a = (a + 0x6D2B79F5) >>> 0;
+        var t = Math.imul(a ^ (a >>> 15), 1 | a);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+}
+
+function identity(n) {
+    var a = [];
+    for (var i = 0; i < n; i++) a.push(i);
+    return a;
+}
+
+function shuffled(n, rnd) {
+    var a = identity(n);
+    for (var i = n - 1; i > 0; i--) {
+        var j = Math.floor(rnd() * (i + 1));
+        var t = a[i]; a[i] = a[j]; a[j] = t;
+    }
+    return a;
+}
+
+/**
+ * Runs dot over many declaration orders and keeps the tidiest result.
+ *
+ * dot itself has no thoroughness dial - mclimit, nslimit and searchsize all
+ * produce byte-identical output on graphs this shape, because it converges long
+ * before those limits bite. The one thing that does move it is the order the
+ * graph is handed over in, so that is what gets searched.
+ */
+function search(viz, persons, relations, blocks, ctx, exhaustive) {
+    var rnd = mulberry32(0x5eed);
+    var started = Date.now();
+    var best = null;
+
+    // Nothing to shuffle: a partial tree (dot handles those in one go), a single
+    // block, or a forest of blocks dot will just line up side by side whatever
+    // order they arrive in.
+    var tries = exhaustive && ctx.links.length && blocks.list.length > 2 ? MAX_ATTEMPTS : 1;
+
+    for (var attempt = 0; attempt < tries; attempt++) {
+        if (attempt >= MIN_ATTEMPTS && Date.now() - started > BUDGET_MS)
+            break;
+
+        var blockOrder = attempt === 0 ? identity(blocks.list.length) : shuffled(blocks.list.length, rnd);
+        var linkOrder = attempt === 0 ? identity(ctx.links.length) : shuffled(ctx.links.length, rnd);
+
+        var json = viz.renderJSON(buildDot(blocks, ctx, blockOrder, linkOrder), { engine: 'dot' });
+        var placed = readBlocks(json, blocks);
+        if (!placed) continue;
+
+        var rows = buildRows(blocks, placed);
+        spread(placed, rows, ctx.kin);
+        pickMemberOrders(blocks, placed, ctx);
+        compact(blocks, placed, ctx, rows);
+        pickMemberOrders(blocks, placed, ctx);
+
+        var pos = expand(blocks, placed, relations);
+        var cost = score(pos, relations, ctx, placed);
+
+        if (best === null || cost < best.cost)
+            best = { cost: cost, pos: pos };
+    }
+
+    if (best === null)
+        throw new Error('dot produced no usable layout');
+
+    return best;
+}
+
+/** Groups the placed blocks into rows, each sorted left to right. */
+function buildRows(blocks, placed) {
+    var rows = {}, i;
+    for (i = 0; i < blocks.list.length; i++) {
+        var block = blocks.list[i];
+        var p = placed[block.name];
+        if (!p) continue;
+        var key = Math.round(p.y);
+        if (!rows[key]) rows[key] = [];
+        rows[key].push(block);
+    }
+
+    var rowList = [];
+    for (var key2 in rows) {
+        if (!Object.prototype.hasOwnProperty.call(rows, key2)) continue;
+        rows[key2].sort(function (a, b) { return placed[a.name].x - placed[b.name].x; });
+        rowList.push(rows[key2]);
+    }
+    return rowList;
+}
+
+/**
+ * Pushes families that are not siblings apart.
+ *
+ * dot laid the row out at the tight gap, because nodesep applies to the whole
+ * graph and siblings need it tight. This opens up every other neighbouring pair
+ * to the wide one. Blocks only ever move right, so the row order that dot chose
+ * - and with it the crossing count - survives untouched.
+ */
+function spread(placed, rowList, kin) {
+    for (var i = 0; i < rowList.length; i++) {
+        var row = rowList[i];
+        for (var j = 1; j < row.length; j++) {
+            var prev = row[j - 1], cur = row[j];
+            var min = placed[prev.name].x + prev.width + gapBetween(kin, prev, cur);
+            if (placed[cur.name].x < min) placed[cur.name].x = min;
+        }
+    }
+}
+
+/**
+ * Slides blocks into the slack dot left behind.
+ *
+ * dot places a block to straighten the block-to-block links it was given, and it
+ * knows nothing about the union points - the little junctions the marriage and
+ * descent wires actually meet at. So a block often sits several hundred pixels
+ * away from where its wires would like it, with an empty gap in between. This
+ * walks every block towards the median of its own wire endpoints, never past its
+ * neighbours, so the row order, the row width and the crossing count all stay
+ * exactly as dot decided them.
+ */
+function compact(blocks, placed, ctx, rowList) {
+    var i, j;
+
+    for (var pass = 0; pass < COMPACT_PASSES; pass++) {
+        var moved = false;
+        for (i = 0; i < rowList.length; i++) {
+            var row = rowList[i];
+            // Alternating the sweep direction keeps a block from being blocked
+            // for good by a neighbour that has not been pulled along yet.
+            var order = identity(row.length);
+            if (pass % 2) order.reverse();
+
+            for (j = 0; j < order.length; j++) {
+                var b = row[order[j]];
+                var target = desiredX(blocks, placed, ctx, b);
+                if (target === null) continue;
+
+                var idx = order[j];
+                var low = idx > 0
+                    ? placed[row[idx - 1].name].x + row[idx - 1].width
+                        + gapBetween(ctx.kin, row[idx - 1], b)
+                    : -Infinity;
+                var high = idx < row.length - 1
+                    ? placed[row[idx + 1].name].x - b.width
+                        - gapBetween(ctx.kin, b, row[idx + 1])
+                    : Infinity;
+
+                var x = Math.min(Math.max(target, low), high);
+                if (Math.abs(x - placed[b.name].x) > 0.5) {
+                    placed[b.name].x = x;
+                    moved = true;
+                }
+            }
+        }
+        if (!moved) break;
+    }
+}
+
+/**
+ * The x this block's wires would put it at: the median of one target per wire,
+ * which is the point that minimises their total horizontal run.
+ */
+function desiredX(blocks, placed, ctx, block) {
+    var order = block.order || block.members;
+    var targets = [];
+    var i, j;
+
+    // wires up to each member's own parents
+    for (i = 0; i < order.length; i++) {
+        var rel = parentRelOf(ctx, order[i]);
+        if (!rel) continue;
+        var u = unionPoint(blocks, placed, ctx, rel);
+        if (u) targets.push(u.x - i * (CARD_WIDTH + COUPLE_GAP) - CARD_WIDTH / 2);
+    }
+
+    // wires down from each of the block's own unions to their children
+    for (i = 0; i < block.relations.length; i++) {
+        var r = block.relations[i];
+        var ia = order.indexOf(r.From), ib = order.indexOf(r.To);
+        if (ia < 0 && ib < 0) continue;
+        var offset = ia >= 0 && ib >= 0
+            ? ((ia + ib) / 2) * (CARD_WIDTH + COUPLE_GAP) + CARD_WIDTH / 2
+            : Math.max(ia, ib) * (CARD_WIDTH + COUPLE_GAP) + CARD_WIDTH / 2;
+
+        var kids = ctx.kids[r.Id] || [];
+        for (j = 0; j < kids.length; j++) {
+            var c = cardCentre(blocks, placed, kids[j]);
+            if (c) targets.push(c.x - offset);
+        }
+    }
+
+    if (!targets.length) return null;
+    targets.sort(function (a, b) { return a - b; });
+    var mid = targets.length >> 1;
+    return targets.length % 2
+        ? targets[mid]
+        : (targets[mid - 1] + targets[mid]) / 2;
+}
+
+/** Reads back the block rectangles, in page coordinates. */
+function readBlocks(json, blocks) {
+    var bb = String(json.bb).split(',');
+    var height = parseFloat(bb[3]);
+    if (!isFinite(height)) return null;
+
+    var placed = {};
+    var objects = json.objects || [];
+    for (var i = 0; i < objects.length; i++) {
+        var o = objects[i];
+        if (!o.pos || o.name === undefined) continue;
+        var block = blocks.byName[o.name];
+        if (!block) continue;
+
+        var parts = o.pos.split(',');
+        placed[block.name] = {
+            x: parseFloat(parts[0]) - block.width / 2,
+            y: (height - parseFloat(parts[1])) - CARD_HEIGHT / 2
+        };
+    }
+    return placed;
+}
+
+/**
+ * Chooses, for every block, which of its candidate arrangements puts the fewest
+ * long horizontal runs on the wires around it.
+ */
+function pickMemberOrders(blocks, placed, ctx) {
+    for (var i = 0; i < blocks.list.length; i++) {
+        var block = blocks.list[i];
+        if (block.orders.length < 2) { block.order = block.orders[0]; continue; }
+        block.order = block.orders[0];
+    }
+
+    // Two sweeps are enough: the first fixes each block against its neighbours'
+    // default arrangement, the second against their chosen one.
+    for (var pass = 0; pass < 2; pass++) {
+        for (var j = 0; j < blocks.list.length; j++) {
+            var b = blocks.list[j];
+            if (b.orders.length < 2 || !placed[b.name]) continue;
+
+            var bestOrder = b.order, bestCost = Infinity;
+            for (var k = 0; k < b.orders.length; k++) {
+                b.order = b.orders[k];
+                var c = localCost(blocks, placed, ctx, b);
+                if (c < bestCost) { bestCost = c; bestOrder = b.orders[k]; }
+            }
+            b.order = bestOrder;
+        }
+    }
+}
+
+/** Where a person's card lands, given the current arrangement of its block. */
+function cardCentre(blocks, placed, personId) {
+    var block = blocks.byId[blocks.blockOf[personId]];
+    if (!block) return null;
+    var p = placed[block.name];
+    if (!p) return null;
+    var order = block.order || block.members;
+    var idx = order.indexOf(personId);
+    if (idx < 0) return null;
+    return {
+        x: p.x + idx * (CARD_WIDTH + COUPLE_GAP) + CARD_WIDTH / 2,
+        y: p.y
+    };
+}
+
+/** Horizontal run of every wire touching the given block. */
+function localCost(blocks, placed, ctx, block) {
+    var total = 0;
+    for (var i = 0; i < block.relations.length; i++)
+        total += unionCost(blocks, placed, ctx, block.relations[i]);
+
+    // marriages of the block's members that live in some other block cannot
+    // happen - a marriage always merges both spouses into one block - so the
+    // only other wires are the ones down to this block's members' own parents.
+    var order = block.order || block.members;
+    for (var j = 0; j < order.length; j++) {
+        var rel = parentRelOf(ctx, order[j]);
+        if (!rel) continue;
+        var u = unionPoint(blocks, placed, ctx, rel);
+        var c = cardCentre(blocks, placed, order[j]);
+        if (u && c) total += Math.abs(u.x - c.x);
+    }
+    return total;
+}
+
+var parentRelCache = null;
+function parentRelOf(ctx, personId) {
+    if (parentRelCache === null || parentRelCache.ctx !== ctx) {
+        parentRelCache = { ctx: ctx, map: {} };
+        for (var relId in ctx.kids) {
+            if (!Object.prototype.hasOwnProperty.call(ctx.kids, relId)) continue;
+            var list = ctx.kids[relId];
+            for (var i = 0; i < list.length; i++)
+                parentRelCache.map[list[i]] = ctx.relById[relId];
+        }
+    }
+    return parentRelCache.map[personId];
+}
+
+function unionPoint(blocks, placed, ctx, rel) {
+    var a = cardCentre(blocks, placed, rel.From),
+        b = cardCentre(blocks, placed, rel.To);
+    var one = a || b;
+    if (!one) return null;
+    return {
+        x: a && b ? (a.x + b.x) / 2 : one.x,
+        y: (a && b ? Math.max(a.y, b.y) : one.y) + CARD_HEIGHT + UNION_DROP
+    };
+}
+
+/** Horizontal run of the marriage wires and the descent wires of one union. */
+function unionCost(blocks, placed, ctx, rel) {
+    var u = unionPoint(blocks, placed, ctx, rel);
+    if (!u) return 0;
+
+    var total = 0;
+    var a = cardCentre(blocks, placed, rel.From),
+        b = cardCentre(blocks, placed, rel.To);
+    if (a) total += Math.abs(a.x - u.x);
+    if (b) total += Math.abs(b.x - u.x);
+
+    var kids = ctx.kids[rel.Id] || [];
+    for (var i = 0; i < kids.length; i++) {
+        var c = cardCentre(blocks, placed, kids[i]);
+        if (c) total += Math.abs(c.x - u.x);
+    }
+    return total;
+}
+
+/** Turns block rectangles plus chosen arrangements into per-person boxes. */
+function expand(blocks, placed, relations) {
+    var pos = {};
+    var i, j;
+
+    for (i = 0; i < blocks.list.length; i++) {
+        var block = blocks.list[i];
+        var p = placed[block.name];
+        if (!p) continue;
+        var order = block.order || block.members;
+        var x = p.x;
+        for (j = 0; j < order.length; j++) {
+            pos[order[j]] = { x: x, y: p.y, width: CARD_WIDTH, height: CARD_HEIGHT };
+            x += CARD_WIDTH + COUPLE_GAP;
+        }
+    }
+
+    // The union point sits centred between the two spouses, just below their row.
+    for (i = 0; i < relations.length; i++) {
+        var rel = relations[i];
+        var a = pos[rel.From], b = pos[rel.To];
+        var one = a || b;
+        if (!one) continue;
+        var cxu = a && b
+            ? (a.x + a.width / 2 + b.x + b.width / 2) / 2
+            : one.x + one.width / 2;
+        var cyu = (a && b ? Math.max(a.y, b.y) : one.y) + CARD_HEIGHT + UNION_DROP;
+        pos[rel.Id] = { x: cxu - 0.5, y: cyu - 0.5, width: 1, height: 1 };
+    }
+
+    return pos;
+}
+
+/** How tangled a candidate layout is: horizontal wire run, plus its width. */
+function score(pos, relations, ctx, placed) {
+    var total = 0, i, j;
+
+    for (i = 0; i < relations.length; i++) {
+        var rel = relations[i];
+        var u = pos[rel.Id];
+        if (!u) continue;
+        var ux = u.x + 0.5;
+
+        var a = pos[rel.From], b = pos[rel.To];
+        if (a) total += Math.abs(a.x + a.width / 2 - ux);
+        if (b) total += Math.abs(b.x + b.width / 2 - ux);
+
+        var kids = ctx.kids[rel.Id] || [];
+        for (j = 0; j < kids.length; j++) {
+            var c = pos[kids[j]];
+            if (!c) continue;
+            total += Math.abs(c.x + c.width / 2 - ux) + Math.abs(c.y - u.y);
+        }
+    }
+
+    var minX = Infinity, maxX = -Infinity;
+    for (var id in pos) {
+        if (!Object.prototype.hasOwnProperty.call(pos, id)) continue;
+        if (pos[id].x < minX) minX = pos[id].x;
+        if (pos[id].x + pos[id].width > maxX) maxX = pos[id].x + pos[id].width;
+    }
+
+    return total + WIDTH_WEIGHT * (maxX - minX);
+}
+
+/**
+ * Slides each union point sideways to line up with its children.
+ *
+ * The point starts centred between the two spouses, so unless the children
+ * happen to be centred there too the descent wire leaves with a short sideways
+ * jog - and a jog of a dozen pixels reads as a kink rather than as a step.
+ *
+ * The point is free to sit anywhere between the two cards' centres: it lives
+ * below both cards, so even at the extremes it only turns one marriage wire
+ * into a straight drop and lengthens the other. That trade is worth it - on the
+ * reference tree this both removes every sub-40px kink and shortens the total
+ * wire run. Runs after the search, on the winning layout only; the search itself
+ * keeps the simpler centred model, which this can only improve on.
+ */
+function alignUnions(pos, relations, ctx) {
+    for (var i = 0; i < relations.length; i++) {
+        var rel = relations[i];
+        var u = pos[rel.Id], a = pos[rel.From], b = pos[rel.To];
+        if (!u || !a || !b) continue;
+
+        var kids = ctx.kids[rel.Id] || [];
+        var sum = 0, n = 0;
+        for (var j = 0; j < kids.length; j++) {
+            var c = pos[kids[j]];
+            if (!c) continue;
+            sum += c.x + c.width / 2;
+            n++;
+        }
+        if (!n) continue;
+
+        var lo = Math.min(a.x, b.x) + CARD_WIDTH / 2,    // centre of the left card
+            hi = Math.max(a.x, b.x) + CARD_WIDTH / 2;    // centre of the right card
+        if (hi < lo) continue;                           // spouses not side by side
+
+        u.x = Math.min(Math.max(sum / n, lo), hi) - u.width / 2;
+    }
+}
+
+function normalize(pos) {
+    var minX = Infinity, minY = Infinity, id;
+    for (id in pos) {
+        if (!Object.prototype.hasOwnProperty.call(pos, id)) continue;
+        if (pos[id].x < minX) minX = pos[id].x;
+        if (pos[id].y < minY) minY = pos[id].y;
+    }
+    if (!isFinite(minX)) return;
+    for (id in pos) {
+        if (!Object.prototype.hasOwnProperty.call(pos, id)) continue;
+        pos[id].x -= minX - SPACING;
+        pos[id].y -= minY - SPACING;
+    }
+}
+
+function measure(pos) {
+    var maxX = 0, maxY = 0;
+    for (var id in pos) {
+        if (!Object.prototype.hasOwnProperty.call(pos, id)) continue;
+        var p = pos[id];
+        if (p.x + p.width > maxX) maxX = p.x + p.width;
+        if (p.y + p.height > maxY) maxY = p.y + p.height;
+    }
+    return { width: Math.ceil(maxX + SPACING), height: Math.ceil(maxY + SPACING) };
+}
+
+function buildChildren(persons, relations, pos) {
+    var children = [];
+    var i;
+
+    for (i = 0; i < persons.length; i++) {
+        var person = persons[i];
+        var p = pos[person.Id];
+        if (!p) continue;
+        children.push({
+            id: person.Id,
+            label: person.Name,
+            x: p.x, y: p.y, width: p.width, height: p.height,
+            info: person
+        });
+    }
+
+    // Union nodes carry no `info`, which is how the front-end tells them apart
+    // from cards (see convertPersons / detectChildren in tree.js).
+    for (i = 0; i < relations.length; i++) {
+        var u = pos[relations[i].Id];
+        if (!u) continue;
+        children.push({
+            id: relations[i].Id,
+            x: u.x, y: u.y, width: 1, height: 1
+        });
+    }
+
+    return children;
+}
+
+// ---------------------------------------------------------------- routing
+
+/** Groups cards into per-row bands, so trunks can be steered around them. */
+function buildBands(pos, persons) {
+    var rows = {};
+    for (var i = 0; i < persons.length; i++) {
+        var p = pos[persons[i].Id];
+        if (!p) continue;
+        var key = Math.round(p.y);
+        if (!rows[key]) rows[key] = { y1: p.y, y2: p.y + p.height, spans: [] };
+        if (p.y + p.height > rows[key].y2) rows[key].y2 = p.y + p.height;
+        rows[key].spans.push({ id: persons[i].Id, x1: p.x, x2: p.x + p.width });
+    }
+
+    var bands = [];
+    for (var key2 in rows) {
+        if (!Object.prototype.hasOwnProperty.call(rows, key2)) continue;
+        rows[key2].spans.sort(function (a, b) { return a.x1 - b.x1; });
+        bands.push(rows[key2]);
+    }
+    bands.sort(function (a, b) { return a.y1 - b.y1; });
+    return bands;
+}
+
+function isFree(band, x, exceptId) {
+    for (var i = 0; i < band.spans.length; i++) {
+        var s = band.spans[i];
+        if (s.id === exceptId) continue;
+        if (x > s.x1 && x < s.x2) return false;
+    }
+    return true;
+}
+
+/** Nearest x to wantX that clears every card in the band. */
+function freeX(band, wantX, exceptId) {
+    var spans = [];
+    var i;
+    for (i = 0; i < band.spans.length; i++)
+        if (band.spans[i].id !== exceptId) spans.push(band.spans[i]);
+
+    if (!spans.length || isFree(band, wantX, exceptId)) return wantX;
+
+    var gaps = [{ from: -Infinity, to: spans[0].x1 - CARD_CLEARANCE }];
+    for (i = 1; i < spans.length; i++) {
+        var from = spans[i - 1].x2 + CARD_CLEARANCE, to = spans[i].x1 - CARD_CLEARANCE;
+        if (to > from) gaps.push({ from: from, to: to });
+    }
+    gaps.push({ from: spans[spans.length - 1].x2 + CARD_CLEARANCE, to: Infinity });
+
+    var best = wantX, bestDist = Infinity;
+    for (i = 0; i < gaps.length; i++) {
+        var c = Math.min(Math.max(wantX, gaps[i].from), gaps[i].to);
+        var d = Math.abs(c - wantX);
+        if (d < bestDist) { bestDist = d; best = c; }
+    }
+    return best;
+}
+
+/**
+ * Walks a trunk down from (x, yFrom) to yTo, stepping sideways into a gap
+ * whenever a row of cards is in the way: a line may cross another line, but
+ * never a card.
+ */
+function descend(bands, x, yFrom, yTo, wantX, exceptId) {
+    var pts = [[x, yFrom]];
+    var cur = x;
+
+    for (var i = 0; i < bands.length; i++) {
+        var band = bands[i];
+        if (band.y2 <= yFrom + 0.5 || band.y1 >= yTo - 0.5) continue;
+        if (isFree(band, cur, exceptId)) continue;
+
+        var lane = freeX(band, wantX, exceptId);
+        var laneY = band.y1 - BUS_RISE;
+        pts.push([cur, laneY]);
+        pts.push([lane, laneY]);
+        cur = lane;
+    }
+
+    pts.push([cur, yTo]);
+    return pts;
+}
+
+function routeEdges(persons, relations, pos, bands) {
+    var edges = [];
+    var i, j;
+
+    // --- marriage lines: person -> union ---------------------------------
+    // Someone with several marriages gets one exit port per marriage, spread
+    // across the bottom of the card and ordered by which side the union is on.
+    var bySpouse = {};
+    for (i = 0; i < relations.length; i++) {
+        var rel = relations[i];
+        pushSpouse(rel.From, rel);
+        pushSpouse(rel.To, rel);
+    }
+
+    function pushSpouse(personId, rel) {
+        if (!pos[personId] || !pos[rel.Id]) return;
+        if (!bySpouse[personId]) bySpouse[personId] = [];
+        bySpouse[personId].push(rel);
+    }
+
+    for (var personId in bySpouse) {
+        if (!Object.prototype.hasOwnProperty.call(bySpouse, personId)) continue;
+        var card = pos[personId];
+        var rels = bySpouse[personId];
+
+        rels.sort(function (a, b) { return pos[a.Id].x - pos[b.Id].x; });
+
+        var usable = card.width - PORT_INSET * 2;
+        for (j = 0; j < rels.length; j++) {
+            var r = rels[j];
+            var px = rels.length === 1
+                ? card.x + card.width / 2
+                : card.x + PORT_INSET + usable * (j + 1) / (rels.length + 1);
+
+            var u = pos[r.Id];
+            var ux = u.x + u.width / 2, uy = u.y + u.height / 2;
+
+            var pts;
+            if (uy >= card.y + card.height)
+                pts = descend(bands, px, card.y + card.height, uy, ux, personId).concat([[ux, uy]]);
+            else
+                pts = [[px, card.y], [px, uy], [ux, uy]];
+
+            // The wire stops exactly on the union point, so the front-end must
+            // not trim its last segment - doing so would leave a childless
+            // marriage as two stubs that never meet.
+            edges.push(makeEdge(
+                r.Id + ':' + personId,
+                [personId],
+                [r.Id + ':n'],
+                false,
+                pts
+            ));
+        }
+    }
+
+    // --- descent lines: union -> children --------------------------------
+    var byUnion = {};
+    for (i = 0; i < persons.length; i++) {
+        var person = persons[i];
+        if (!person.Parents || !pos[person.Parents] || !pos[person.Id]) continue;
+        if (!byUnion[person.Parents]) byUnion[person.Parents] = [];
+        byUnion[person.Parents].push(person);
+    }
+
+    for (var unionId in byUnion) {
+        if (!Object.prototype.hasOwnProperty.call(byUnion, unionId)) continue;
+        var un = pos[unionId];
+        var unx = un.x + un.width / 2, uny = un.y + un.height / 2;
+
+        // Children that ended up on different rows each get their own bus; a
+        // single shared bus would leave the lower ones hanging off a drop that
+        // has to cross whatever sits in between.
+        var rowsOf = {};
+        var kids = byUnion[unionId];
+        for (i = 0; i < kids.length; i++) {
+            var kp = pos[kids[i].Id];
+            var rowKey = Math.round(kp.y);
+            if (!rowsOf[rowKey]) rowsOf[rowKey] = [];
+            rowsOf[rowKey].push(kids[i]);
+        }
+
+        for (var rowKey2 in rowsOf) {
+            if (!Object.prototype.hasOwnProperty.call(rowsOf, rowKey2)) continue;
+            var group = rowsOf[rowKey2];
+            var rowY = pos[group[0].Id].y;
+            var busY = (rowY - BUS_RISE > uny) ? rowY - BUS_RISE : uny;
+
+            var centre = 0;
+            for (i = 0; i < group.length; i++)
+                centre += pos[group[i].Id].x + CARD_WIDTH / 2;
+            centre /= group.length;
+
+            // The sideways step of a lone child lands halfway down the band,
+            // UNION_DROP below the union and BUS_RISE above the card, so it
+            // reads as a deliberate step rather than a notch against the card.
+            var trunk = descend(bands, unx, uny, busY, centre, null);
+
+            for (i = 0; i < group.length; i++) {
+                var child = group[i];
+                var cp = pos[child.Id];
+                var ccx = cp.x + cp.width / 2;
+                edges.push(makeEdge(
+                    child.Id + ':' + unionId,
+                    [unionId + ':s'],
+                    [child.Id + ':n'],
+                    false,
+                    trunk.concat([[ccx, busY], [ccx, cp.y]])
+                ));
             }
         }
     }
 
-    function processRelations() {
-        // registers marriage pseudo-nodes
-        for (var i = 0; i < data.Relations.length; i++) {
-            var rel = data.Relations[i];
-            nodes.push({
-                id: rel.Id,
-                width: 1,
-                height: 1,
-                layoutOptions: {
-                    'elk.portConstraints': 'FIXED_SIDE'
-                },
-                ports: [
-                    {
-                        id: rel.Id + ":n",
-                        layoutOptions: {
-                            'elk.port.side': 'NORTH'
-                        }
-                    },
-                    {
-                        id: rel.Id + ":s",
-                        layoutOptions: {
-                            'elk.port.side': 'SOUTH'
-                        }
-                    }
-                ]
-            });
+    return edges;
+}
 
-            edges.push({
-                id: rel.Id + ':' + rel.From,
-                sources: [rel.From],
-                targets: [rel.Id + ':n'],
-                info: {
-                    fakeTarget: true
-                }
-            });
-
-            edges.push({
-                id: rel.Id + ':' + rel.To,
-                sources: [rel.To],
-                targets: [rel.Id + ':n'],
-                info: {
-                    fakeTarget: true
-                }
-            });
-        }
+/** Packs a polyline into the section shape the front-end expects. */
+function makeEdge(id, sources, targets, fakeTarget, points) {
+    var clean = [];
+    for (var i = 0; i < points.length; i++) {
+        var last = clean[clean.length - 1];
+        if (!last || last[0] !== points[i][0] || last[1] !== points[i][1])
+            clean.push(points[i]);
     }
+    if (clean.length < 2) clean.push([clean[0][0], clean[0][1]]);
+
+    // Drop points that sit on the straight line between their neighbours: the
+    // trunk builder emits one per row it walks past, and a redundant bend makes
+    // a straight run look like a decision.
+    for (var k = clean.length - 2; k > 0; k--) {
+        var prev = clean[k - 1], cur = clean[k], next = clean[k + 1];
+        if ((prev[0] === cur[0] && cur[0] === next[0]) ||
+            (prev[1] === cur[1] && cur[1] === next[1]))
+            clean.splice(k, 1);
+    }
+
+    var bends = [];
+    for (var j = 1; j < clean.length - 1; j++)
+        bends.push({ x: clean[j][0], y: clean[j][1] });
+
+    return {
+        id: id,
+        sources: sources,
+        targets: targets,
+        info: { fakeTarget: fakeTarget },
+        sections: [{
+            id: id + '_s0',
+            startPoint: { x: clean[0][0], y: clean[0][1] },
+            endPoint: { x: clean[clean.length - 1][0], y: clean[clean.length - 1][1] },
+            bendPoints: bends
+        }]
+    };
 }

--- a/src/Bonsai/Areas/Admin/Controllers/ChangesetsController.cs
+++ b/src/Bonsai/Areas/Admin/Controllers/ChangesetsController.cs
@@ -1,9 +1,12 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Bonsai.Areas.Admin.Logic.Changesets;
+using Bonsai.Areas.Admin.Logic.Tree;
 using Bonsai.Areas.Admin.ViewModels.Changesets;
+using Bonsai.Code.Services.Jobs;
 using Bonsai.Code.Utils;
 using Bonsai.Data;
+using Bonsai.Data.Models;
 using Bonsai.Localization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -13,7 +16,7 @@ namespace Bonsai.Areas.Admin.Controllers;
 /// Controller for managing changesets.
 /// </summary>
 [Route("admin/changes")]
-public class ChangesetsController(ChangesetsManagerService changesSvc, AppDbContext db) : AdminControllerBase
+public class ChangesetsController(ChangesetsManagerService changesSvc, AppDbContext db, IBackgroundJobService jobs) : AdminControllerBase
 {
     protected override Type ListStateType => typeof(ChangesetsListRequestVM);
 
@@ -68,6 +71,10 @@ public class ChangesetsController(ChangesetsManagerService changesSvc, AppDbCont
 
         await changesSvc.RevertChangeAsync(id, User);
         await db.SaveChangesAsync();
+
+        // reverting a page or a relation can add, remove or rewire tree nodes
+        if (editVm.EntityType is ChangesetEntityType.Page or ChangesetEntityType.Relation)
+            await jobs.RunAsync(JobBuilder.For<TreeLayoutJob>().SupersedeAll());
 
         return RedirectToSuccess(Texts.Admin_Changesets_RevertedMessage);
     }

--- a/src/Bonsai/Areas/Admin/Controllers/DynamicConfigController.cs
+++ b/src/Bonsai/Areas/Admin/Controllers/DynamicConfigController.cs
@@ -54,8 +54,7 @@ public class DynamicConfigController(DynamicConfigManagerService configMgr, Bons
 
         bool IsTreeConfigChanged()
         {
-            return oldValue.TreeRenderThoroughness != vm.TreeRenderThoroughness
-                   || oldValue.TreeKinds?.JoinString(",") != vm.TreeKinds?.JoinString(",")
+            return oldValue.TreeKinds?.JoinString(",") != vm.TreeKinds?.JoinString(",")
                    || oldValue.TreeDirection != vm.TreeDirection
                    || oldValue.TreeViewMode != vm.TreeViewMode;
         }

--- a/src/Bonsai/Areas/Admin/Controllers/DynamicConfigController.cs
+++ b/src/Bonsai/Areas/Admin/Controllers/DynamicConfigController.cs
@@ -55,7 +55,9 @@ public class DynamicConfigController(DynamicConfigManagerService configMgr, Bons
         bool IsTreeConfigChanged()
         {
             return oldValue.TreeRenderThoroughness != vm.TreeRenderThoroughness
-                   || oldValue.TreeKinds?.JoinString(",") != vm.TreeKinds?.JoinString(",");
+                   || oldValue.TreeKinds?.JoinString(",") != vm.TreeKinds?.JoinString(",")
+                   || oldValue.TreeDirection != vm.TreeDirection
+                   || oldValue.TreeViewMode != vm.TreeViewMode;
         }
     }
 }

--- a/src/Bonsai/Areas/Admin/Logic/Tree/TreeLayoutEngine.cs
+++ b/src/Bonsai/Areas/Admin/Logic/Tree/TreeLayoutEngine.cs
@@ -1,0 +1,1828 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Bonsai.Areas.Admin.ViewModels.Tree;
+using Bonsai.Code.Services.Graphviz;
+using Bonsai.Data.Models;
+using Newtonsoft.Json.Linq;
+
+namespace Bonsai.Areas.Admin.Logic.Tree;
+
+/// <summary>
+/// Calculates the layout of a family tree.
+///
+/// Graphviz only ever decides where the cards go: it is handed a graph of family
+/// blocks (a couple merged into one wide node), and everything else - the gaps
+/// inside a row, the choice of which spouse stands on which side, the union
+/// points and every wire - is worked out here. dot has no notion of "keep these
+/// two nodes adjacent", which is why the couples are merged before layout.
+/// </summary>
+public class TreeLayoutEngine
+{
+    public TreeLayoutEngine(IGraphvizService graphviz)
+    {
+        _graphviz = graphviz;
+    }
+
+    private readonly IGraphvizService _graphviz;
+
+    #region Constants
+
+    private const double Spacing = 30;      // margin around the whole canvas
+    private const double RankSep = 0.75;    // dot units (inches); 0.42 starts producing crossings
+    private const double NodeSep = 0.56;
+
+    // The vertical band between two rows of cards, and how the wires divide it up.
+    // Every horizontal run in the band - the marriage brackets, the sibling buses,
+    // and the lanes a trunk steps into to get past a row - gets a shelf of its own
+    // one LaneStep from the next, otherwise runs collapse into one another and read
+    // as noise, or worse, as a line that means something (see LaneMap). A band deep
+    // enough for one bracket shelf, one bus shelf and the clearance between them is
+    // exactly the RowGap dot leaves; ExpandRows opens up the ones that need more.
+    private static readonly double RowGap = JsRound(RankSep * 72);
+    private static readonly double LaneStep = JsRound(RowGap / 3);
+    private static readonly double UnionDrop = LaneStep;                // card bottom -> union point
+    private const double CardClearance = 20;                            // sideways room when dodging a card
+
+    // A row wants two different minimum gaps, and dot's nodesep is a single number
+    // for the whole graph. So dot lays the row out at the tight one and Spread()
+    // opens up the pairs that deserve the wide one.
+    private static readonly double KinGap = JsRound(NodeSep * 72);      // between siblings: keep the group tight
+    private static readonly double StrangerGap = KinGap * 2;            // between families with no sibling link
+
+    // dot's result depends on the order the nodes and edges are declared in, and the
+    // spread between a lucky and an unlucky order is large (25% on total edge length
+    // on the reference tree). So the layout is run many times over shuffled orders
+    // and the best-scoring one is kept.
+    // This only pays off for the full tree: the partial trees (ancestors, descendants,
+    // close family) are narrow and near-hierarchical, dot gets them right on the first
+    // order, and they are rendered once per page - so they run a single attempt.
+    private const int MinAttempts = 8;          // always try at least this many orders
+    private const int MaxAttempts = 400;
+    private const int BudgetMs = 2000;          // stop shuffling once this much time has been spent
+    private const int BatchSize = 25;           // candidates handed to dot per invocation
+    private const int CompactPasses = 24;       // sweeps of the slide-into-the-slack pass
+    private const double WidthWeight = 8;       // px of edge length one px of extra width is worth
+
+    #endregion
+
+    #region Per-run card geometry
+
+    // The card geometry of the two views. Everything about a row is measured in
+    // these numbers, so switching the view is a matter of setting them before the
+    // layout runs: dot gets smaller nodes and every gap expressed in card terms
+    // follows along. The compact card is half as wide, a little shorter, and keeps
+    // its couple gap and marriage ports in proportion to that.
+    private double _cardWidth;      // card box, as the front-end will render it
+    private double _cardHeight;
+    private double _coupleGap;      // gap between two spouses inside one family block
+    private double _portInset;      // keeps the marriage ports off the card corners
+
+    /// <summary>
+    /// Sets the card geometry for the requested view.
+    /// </summary>
+    private void ApplyView(TreeViewMode view)
+    {
+        if (view == TreeViewMode.Compact)
+            (_cardWidth, _cardHeight, _coupleGap, _portInset) = (150, 76, 30, 20);
+        else
+            (_cardWidth, _cardHeight, _coupleGap, _portInset) = (300, 100, 60, 40);
+    }
+
+    #endregion
+
+    #region Entry point
+
+    /// <summary>
+    /// Calculates the layout of a tree and returns it as the JSON the front-end reads.
+    /// </summary>
+    /// <param name="data">Tree contents.</param>
+    /// <param name="exhaustive">
+    /// Search over many declaration orders and keep the tidiest layout, instead of
+    /// taking dot's first result as it comes.
+    /// </param>
+    /// <param name="direction">Whether the parents go on top or at the bottom.</param>
+    /// <param name="view">Card size.</param>
+    /// <param name="token">Cancellation token.</param>
+    public async Task<string> LayoutAsync(TreeLayoutVM data, bool exhaustive, TreeDirection direction, TreeViewMode view, CancellationToken token)
+    {
+        ApplyView(view);
+
+        // CanonicalPersons() is order-insensitive, so it gets the payload as it came;
+        // everything downstream works off the id-sorted copy.
+        var persons = CanonicalPersons(data.Persons ?? [], data.Relations ?? []);
+        var relations = (data.Relations ?? []).OrderBy(x => x.Id, StringComparer.Ordinal).ToList();
+
+        var blocks = BuildBlocks(persons, relations);
+        var ctx = BuildContext(persons, relations, blocks);
+
+        var pos = await SearchAsync(persons, relations, blocks, ctx, exhaustive, token);
+
+        Normalize(pos);
+        AlignUnions(pos, relations, ctx);
+
+        // The wires are routed twice. The first pass runs on the layout as dot left
+        // it and only hands out lane numbers, which is what tells us how many
+        // horizontal runs each band between two rows has to hold; the rows are then
+        // pushed apart far enough to give every run a lane of its own, and the second
+        // pass draws the wires for real. A lane number depends only on the x range of
+        // the run, and no x moves when rows slide down, so both passes agree on who
+        // gets which lane.
+        var flat = BuildBands(pos, persons);
+        var probe = new LaneMap { Flat = true };
+        RouteEdges(persons, relations, pos, flat, probe);
+        ExpandRows(pos, persons, flat, probe);
+
+        var bands = BuildBands(pos, persons);
+        var edges = RouteEdges(persons, relations, pos, bands, new LaneMap());
+        var size = Measure(pos);
+
+        var tree = new JObject
+        {
+            ["id"] = "root",
+            ["width"] = size.Width,
+            ["height"] = size.Height,
+            ["children"] = BuildChildren(persons, relations, pos),
+            ["edges"] = edges
+        };
+
+        if (direction == TreeDirection.BottomToTop)
+            FlipVertical(tree, size.Height);
+
+        return tree.ToString(Newtonsoft.Json.Formatting.None);
+    }
+
+    #endregion
+
+    #region Person ordering
+
+    /// <summary>
+    /// Sorts the persons into an order that does not depend on the ids.
+    ///
+    /// The backend invents a fresh random Guid for every "unknown spouse" placeholder
+    /// on every run, so an id-derived order makes the layout differ from run to run
+    /// for no reason. Sorting by name plus the surrounding names pins it down.
+    /// </summary>
+    private static List<TreePersonVM> CanonicalPersons(IReadOnlyList<TreePersonVM> persons, IReadOnlyList<TreeRelationVM> relations)
+    {
+        var name = new Dictionary<string, string>();
+        foreach (var p in persons)
+            name[p.Id] = p.Name ?? "";
+
+        var spouses = new Dictionary<string, List<string>>();
+        var kids = new Dictionary<string, List<string>>();
+
+        foreach (var rel in relations)
+        {
+            Add(spouses, rel.From, name.GetValueOrDefault(rel.To) ?? "");
+            Add(spouses, rel.To, name.GetValueOrDefault(rel.From) ?? "");
+        }
+
+        foreach (var p in persons)
+        {
+            if (p.Parents != null)
+                Add(kids, p.Parents, p.Name ?? "");
+        }
+
+        var keyed = new List<(TreePersonVM Person, string Key, int Index)>();
+        for (var i = 0; i < persons.Count; i++)
+        {
+            var person = persons[i];
+
+            var own = spouses.TryGetValue(person.Id, out var mine)
+                ? string.Join(",", mine.OrderBy(x => x, StringComparer.Ordinal))
+                : "";
+
+            var below = new List<string>();
+            foreach (var rel in relations)
+            {
+                if (rel.From == person.Id || rel.To == person.Id)
+                {
+                    if (kids.TryGetValue(rel.Id, out var list))
+                        below.AddRange(list);
+                }
+            }
+            below.Sort(StringComparer.Ordinal);
+
+            var key = (person.Name ?? "") + (person.Parents ?? "") + own + string.Join(",", below);
+            keyed.Add((person, key, i));
+        }
+
+        keyed.Sort((a, b) =>
+        {
+            var byKey = string.CompareOrdinal(a.Key, b.Key);
+            return byKey != 0 ? byKey : a.Index - b.Index;
+        });
+
+        return keyed.Select(x => x.Person).ToList();
+    }
+
+    private static void Add<T>(Dictionary<string, List<T>> map, string key, T value)
+    {
+        if (key == null)
+            return;
+
+        if (!map.TryGetValue(key, out var list))
+            map[key] = list = [];
+
+        list.Add(value);
+    }
+
+    #endregion
+
+    #region Family blocks
+
+    /// <summary>
+    /// Merges every couple into a single wide node. dot's crossing minimisation has
+    /// no notion of "keep these two nodes adjacent", so without this a stranger's
+    /// card can end up wedged between two spouses.
+    /// </summary>
+    private Blocks BuildBlocks(IReadOnlyList<TreePersonVM> persons, IReadOnlyList<TreeRelationVM> relations)
+    {
+        var parent = new Dictionary<string, string>();
+        foreach (var p in persons)
+            parent[p.Id] = p.Id;
+
+        string Find(string x)
+        {
+            while (parent[x] != x)
+            {
+                parent[x] = parent[parent[x]];
+                x = parent[x];
+            }
+            return x;
+        }
+
+        foreach (var rel in relations)
+        {
+            if (!parent.ContainsKey(rel.From) || !parent.ContainsKey(rel.To))
+                continue;
+
+            var ra = Find(rel.From);
+            var rb = Find(rel.To);
+            if (ra != rb)
+                parent[ra] = rb;
+        }
+
+        var byRoot = new Dictionary<string, Block>();
+        var list = new List<Block>();
+        var blockOf = new Dictionary<string, string>();
+
+        foreach (var p in persons)
+        {
+            var root = Find(p.Id);
+            if (!byRoot.TryGetValue(root, out var block))
+            {
+                byRoot[root] = block = new Block { Id = root, Name = "b" + list.Count };
+                list.Add(block);
+            }
+
+            block.Members.Add(p.Id);
+            blockOf[p.Id] = root;
+        }
+
+        foreach (var rel in relations)
+        {
+            if (!parent.ContainsKey(rel.From))
+                continue;
+
+            if (byRoot.TryGetValue(Find(rel.From), out var block))
+                block.Relations.Add(rel);
+        }
+
+        var byName = new Dictionary<string, Block>();
+        foreach (var block in list)
+        {
+            block.Members = ChainMembers(block.Members, block.Relations);
+            block.Width = block.Members.Count * _cardWidth + (block.Members.Count - 1) * _coupleGap;
+            block.Orders = MemberOrders(block);
+            byName[block.Name] = block;
+        }
+
+        return new Blocks { List = list, ById = byRoot, ByName = byName, BlockOf = blockOf };
+    }
+
+    /// <summary>
+    /// Orders a block's members along the marriage chain, so spouses touch.
+    /// </summary>
+    private static List<string> ChainMembers(List<string> members, List<TreeRelationVM> relations)
+    {
+        if (members.Count < 2)
+            return members;
+
+        var adj = new Dictionary<string, List<string>>();
+        foreach (var m in members)
+            adj[m] = [];
+
+        foreach (var rel in relations)
+        {
+            if (adj.ContainsKey(rel.From) && adj.ContainsKey(rel.To))
+            {
+                adj[rel.From].Add(rel.To);
+                adj[rel.To].Add(rel.From);
+            }
+        }
+
+        var start = members[0];
+        foreach (var m in members)
+        {
+            if (adj[m].Count == 1)
+            {
+                start = m;
+                break;
+            }
+        }
+
+        var seen = new HashSet<string>();
+        var order = new List<string>();
+        var stack = new Stack<string>();
+        stack.Push(start);
+
+        while (stack.Count > 0)
+        {
+            var id = stack.Pop();
+            if (!seen.Add(id))
+                continue;
+
+            order.Add(id);
+
+            var next = adj[id];
+            for (var i = next.Count - 1; i >= 0; i--)
+            {
+                if (!seen.Contains(next[i]))
+                    stack.Push(next[i]);
+            }
+        }
+
+        foreach (var m in members)
+        {
+            if (!seen.Contains(m))
+                order.Add(m);
+        }
+
+        return order;
+    }
+
+    /// <summary>
+    /// The candidate left-to-right arrangements of one block's cards.
+    ///
+    /// Which spouse stands on which side is free, and picking the wrong side leaves a
+    /// long diagonal run to the parents. Small blocks get every permutation that
+    /// keeps married pairs touching; larger ones just get the chain and its mirror.
+    /// </summary>
+    private static List<List<string>> MemberOrders(Block block)
+    {
+        var members = block.Members;
+        if (members.Count < 2)
+            return [members];
+
+        if (members.Count > 4)
+            return [members, Enumerable.Reverse(members).ToList()];
+
+        var married = new HashSet<string>();
+        foreach (var rel in block.Relations)
+        {
+            married.Add(rel.From + " " + rel.To);
+            married.Add(rel.To + " " + rel.From);
+        }
+
+        var best = new List<List<string>>();
+        var bestPairs = -1;
+
+        Permute(members, order =>
+        {
+            var pairs = 0;
+            for (var j = 1; j < order.Count; j++)
+            {
+                if (married.Contains(order[j - 1] + " " + order[j]))
+                    pairs++;
+            }
+
+            if (pairs > bestPairs)
+            {
+                bestPairs = pairs;
+                best = [order];
+            }
+            else if (pairs == bestPairs)
+            {
+                best.Add(order);
+            }
+        });
+
+        return best;
+    }
+
+    private static void Permute(List<string> items, Action<List<string>> fn)
+    {
+        var acc = new List<string>();
+
+        void Step(List<string> rest)
+        {
+            if (rest.Count == 0)
+            {
+                fn([..acc]);
+                return;
+            }
+
+            for (var i = 0; i < rest.Count; i++)
+            {
+                acc.Add(rest[i]);
+
+                var next = new List<string>(rest.Count - 1);
+                next.AddRange(rest.Take(i));
+                next.AddRange(rest.Skip(i + 1));
+                Step(next);
+
+                acc.RemoveAt(acc.Count - 1);
+            }
+        }
+
+        Step(items);
+    }
+
+    #endregion
+
+    #region Context
+
+    /// <summary>
+    /// Precomputes the parent/child wiring the scorer needs, in block terms.
+    /// </summary>
+    private static Ctx BuildContext(IReadOnlyList<TreePersonVM> persons, IReadOnlyList<TreeRelationVM> relations, Blocks blocks)
+    {
+        var relById = new Dictionary<string, TreeRelationVM>();
+        foreach (var rel in relations)
+            relById[rel.Id] = rel;
+
+        // block -> block links, one per distinct pair, as dot sees them
+        var links = new List<Link>();
+        var seen = new HashSet<string>();
+
+        // union -> children, as the scorer sees them
+        var kids = new Dictionary<string, List<string>>();
+
+        foreach (var person in persons)
+        {
+            if (person.Parents == null)
+                continue;
+
+            if (!relById.TryGetValue(person.Parents, out var rel))
+                continue;
+
+            Add(kids, rel.Id, person.Id);
+
+            var from = blocks.BlockOf.GetValueOrDefault(rel.From) ?? blocks.BlockOf.GetValueOrDefault(rel.To);
+            var to = blocks.BlockOf.GetValueOrDefault(person.Id);
+            if (from == null || to == null || from == to)
+                continue;
+
+            if (!seen.Add(from + " " + to))     // dot only needs the family link once
+                continue;
+
+            links.Add(new Link(blocks.ById[from].Name, blocks.ById[to].Name));
+        }
+
+        var ctx = new Ctx { Links = links, Kids = kids, RelById = relById };
+        ctx.Kin = BuildKin(relations, ctx, blocks);
+        ctx.ParentRelOf = BuildParentRels(ctx);
+        return ctx;
+    }
+
+    /// <summary>
+    /// The pairs of blocks that may stand close together.
+    ///
+    /// Siblings read as one group and should stay tight; two families with no such
+    /// link should be visibly apart. Gathering the children per *person* rather than
+    /// per union means half-siblings, who share only one parent, count as kin too.
+    /// </summary>
+    private static HashSet<string> BuildKin(IReadOnlyList<TreeRelationVM> relations, Ctx ctx, Blocks blocks)
+    {
+        var byPerson = new Dictionary<string, List<string>>();
+
+        foreach (var rel in relations)
+        {
+            foreach (var kid in ctx.Kids.GetValueOrDefault(rel.Id) ?? [])
+            {
+                var root = blocks.BlockOf.GetValueOrDefault(kid);
+                if (root == null)
+                    continue;
+
+                var blockName = blocks.ById[root].Name;
+                Add(byPerson, rel.From, blockName);
+                Add(byPerson, rel.To, blockName);
+            }
+        }
+
+        var kin = new HashSet<string>();
+        foreach (var list in byPerson.Values)
+        {
+            for (var j = 0; j < list.Count; j++)
+            {
+                for (var k = j + 1; k < list.Count; k++)
+                {
+                    if (list[j] != list[k])
+                        kin.Add(PairKey(list[j], list[k]));
+                }
+            }
+        }
+
+        return kin;
+    }
+
+    /// <summary>
+    /// Maps every person to the union they descend from.
+    /// </summary>
+    private static Dictionary<string, TreeRelationVM> BuildParentRels(Ctx ctx)
+    {
+        var map = new Dictionary<string, TreeRelationVM>();
+        foreach (var (relId, list) in ctx.Kids)
+        {
+            foreach (var personId in list)
+                map[personId] = ctx.RelById[relId];
+        }
+        return map;
+    }
+
+    private static string PairKey(string a, string b)
+    {
+        return string.CompareOrdinal(a, b) < 0 ? a + " " + b : b + " " + a;
+    }
+
+    /// <summary>
+    /// The minimum gap the row must leave between two neighbouring blocks.
+    /// </summary>
+    private static double GapBetween(HashSet<string> kin, Block a, Block b)
+    {
+        return kin.Contains(PairKey(a.Name, b.Name)) ? KinGap : StrangerGap;
+    }
+
+    #endregion
+
+    #region DOT source
+
+    private string BuildDot(Blocks blocks, Ctx ctx, IReadOnlyList<int> blockOrder, IReadOnlyList<int> linkOrder)
+    {
+        var sb = new StringBuilder();
+        sb.Append("digraph G {\n");
+        sb.Append("  graph [rankdir=TB, ranksep=\"").Append(Num(RankSep)).Append("\", nodesep=\"").Append(Num(NodeSep)).Append("\"];\n");
+        sb.Append("  node [shape=box, fixedsize=true, height=\"").Append(Num(_cardHeight / 72)).Append("\", label=\"\"];\n");
+        sb.Append("  edge [arrowhead=none];\n");
+
+        foreach (var i in blockOrder)
+        {
+            var b = blocks.List[i];
+            sb.Append("  ").Append(b.Name).Append(" [width=\"").Append(Num(b.Width / 72)).Append("\"];\n");
+        }
+
+        foreach (var i in linkOrder)
+        {
+            var link = ctx.Links[i];
+            sb.Append("  ").Append(link.From).Append(" -> ").Append(link.To).Append(";\n");
+        }
+
+        sb.Append('}');
+        return sb.ToString();
+    }
+
+    private static string Num(double value)
+    {
+        return value.ToString("R", CultureInfo.InvariantCulture);
+    }
+
+    #endregion
+
+    #region Search
+
+    /// <summary>
+    /// Runs dot over many declaration orders and keeps the tidiest result.
+    ///
+    /// dot itself has no thoroughness dial - mclimit, nslimit and searchsize all
+    /// produce byte-identical output on graphs this shape, because it converges long
+    /// before those limits bite. The one thing that does move it is the order the
+    /// graph is handed over in, so that is what gets searched.
+    ///
+    /// The orders come out of a seeded generator and so do not depend on any
+    /// previous result, which lets a whole batch of candidates be laid out in one
+    /// dot invocation instead of one process per attempt.
+    /// </summary>
+    private async Task<Dictionary<string, Rect>> SearchAsync(
+        IReadOnlyList<TreePersonVM> persons,
+        IReadOnlyList<TreeRelationVM> relations,
+        Blocks blocks,
+        Ctx ctx,
+        bool exhaustive,
+        CancellationToken token)
+    {
+        var rnd = new Mulberry32(0x5eed);
+        var started = System.Diagnostics.Stopwatch.StartNew();
+
+        Dictionary<string, Rect> best = null;
+        var bestCost = double.PositiveInfinity;
+
+        // Nothing to shuffle: a partial tree (dot handles those in one go), a single
+        // block, or a forest of blocks dot will just line up side by side whatever
+        // order they arrive in.
+        var tries = exhaustive && ctx.Links.Count > 0 && blocks.List.Count > 2 ? MaxAttempts : 1;
+
+        var attempt = 0;
+        while (attempt < tries)
+        {
+            // The first batch is kept to the minimum number of attempts, so that a
+            // tree slow enough to blow the budget on its own does not first pay for
+            // a full batch of candidates it will never look at.
+            var batch = new List<string>();
+            var batchEnd = Math.Min(attempt + (attempt == 0 ? MinAttempts : BatchSize), tries);
+            for (var i = attempt; i < batchEnd; i++)
+            {
+                var blockOrder = i == 0 ? Identity(blocks.List.Count) : Shuffled(blocks.List.Count, rnd);
+                var linkOrder = i == 0 ? Identity(ctx.Links.Count) : Shuffled(ctx.Links.Count, rnd);
+                batch.Add(BuildDot(blocks, ctx, blockOrder, linkOrder));
+            }
+
+            var layouts = await _graphviz.RenderAsync(batch, token);
+
+            foreach (var layout in layouts)
+            {
+                var placed = ReadBlocks(layout, blocks);
+                if (placed == null)
+                    continue;
+
+                var rows = BuildRows(blocks, placed);
+                Spread(placed, rows, ctx.Kin);
+                PickMemberOrders(blocks, placed, ctx);
+                Compact(blocks, placed, ctx, rows);
+                PickMemberOrders(blocks, placed, ctx);
+
+                var pos = Expand(blocks, placed, relations);
+                var cost = Score(pos, relations, ctx);
+
+                if (best == null || cost < bestCost)
+                {
+                    bestCost = cost;
+                    best = pos;
+                }
+            }
+
+            attempt = batchEnd;
+
+            if (attempt >= MinAttempts && started.ElapsedMilliseconds > BudgetMs)
+                break;
+        }
+
+        if (best == null)
+            throw new Exception("dot produced no usable layout");
+
+        return best;
+    }
+
+    private static int[] Identity(int n)
+    {
+        var a = new int[n];
+        for (var i = 0; i < n; i++)
+            a[i] = i;
+        return a;
+    }
+
+    private static int[] Shuffled(int n, Mulberry32 rnd)
+    {
+        var a = Identity(n);
+        for (var i = n - 1; i > 0; i--)
+        {
+            var j = (int)Math.Floor(rnd.Next() * (i + 1));
+            (a[i], a[j]) = (a[j], a[i]);
+        }
+        return a;
+    }
+
+    /// <summary>
+    /// Reads back the block rectangles, in page coordinates.
+    /// </summary>
+    private Dictionary<string, Placed> ReadBlocks(GraphvizLayout layout, Blocks blocks)
+    {
+        if (double.IsNaN(layout.Height) || double.IsInfinity(layout.Height))
+            return null;
+
+        var placed = new Dictionary<string, Placed>();
+        foreach (var (name, point) in layout.Nodes)
+        {
+            if (!blocks.ByName.TryGetValue(name, out var block))
+                continue;
+
+            placed[block.Name] = new Placed
+            {
+                X = point.X - block.Width / 2,
+                Y = layout.Height - point.Y - _cardHeight / 2
+            };
+        }
+
+        return placed;
+    }
+
+    /// <summary>
+    /// Groups the placed blocks into rows, each sorted left to right.
+    /// </summary>
+    private static List<List<Block>> BuildRows(Blocks blocks, Dictionary<string, Placed> placed)
+    {
+        var rows = new Dictionary<double, List<Block>>();
+        foreach (var block in blocks.List)
+        {
+            if (!placed.TryGetValue(block.Name, out var p))
+                continue;
+
+            var key = JsRound(p.Y);
+            if (!rows.TryGetValue(key, out var row))
+                rows[key] = row = [];
+
+            row.Add(block);
+        }
+
+        var rowList = new List<List<Block>>();
+        foreach (var key in rows.Keys.OrderBy(x => x))
+        {
+            var row = rows[key];
+            row.Sort((a, b) => placed[a.Name].X.CompareTo(placed[b.Name].X));
+            rowList.Add(row);
+        }
+
+        return rowList;
+    }
+
+    /// <summary>
+    /// Pushes families that are not siblings apart.
+    ///
+    /// dot laid the row out at the tight gap, because nodesep applies to the whole
+    /// graph and siblings need it tight. This opens up every other neighbouring pair
+    /// to the wide one. Blocks only ever move right, so the row order that dot chose
+    /// - and with it the crossing count - survives untouched.
+    /// </summary>
+    private static void Spread(Dictionary<string, Placed> placed, List<List<Block>> rowList, HashSet<string> kin)
+    {
+        foreach (var row in rowList)
+        {
+            for (var j = 1; j < row.Count; j++)
+            {
+                var prev = row[j - 1];
+                var cur = row[j];
+                var min = placed[prev.Name].X + prev.Width + GapBetween(kin, prev, cur);
+                if (placed[cur.Name].X < min)
+                    placed[cur.Name].X = min;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Slides blocks into the slack dot left behind.
+    ///
+    /// dot places a block to straighten the block-to-block links it was given, and it
+    /// knows nothing about the union points - the little junctions the marriage and
+    /// descent wires actually meet at. So a block often sits several hundred pixels
+    /// away from where its wires would like it, with an empty gap in between. This
+    /// walks every block towards the median of its own wire endpoints, never past its
+    /// neighbours, so the row order, the row width and the crossing count all stay
+    /// exactly as dot decided them.
+    /// </summary>
+    private void Compact(Blocks blocks, Dictionary<string, Placed> placed, Ctx ctx, List<List<Block>> rowList)
+    {
+        for (var pass = 0; pass < CompactPasses; pass++)
+        {
+            var moved = false;
+            foreach (var row in rowList)
+            {
+                // Alternating the sweep direction keeps a block from being blocked
+                // for good by a neighbour that has not been pulled along yet.
+                var order = Identity(row.Count);
+                if (pass % 2 == 1)
+                    Array.Reverse(order);
+
+                foreach (var idx in order)
+                {
+                    var b = row[idx];
+                    var target = DesiredX(blocks, placed, ctx, b);
+                    if (target == null)
+                        continue;
+
+                    var low = idx > 0
+                        ? placed[row[idx - 1].Name].X + row[idx - 1].Width + GapBetween(ctx.Kin, row[idx - 1], b)
+                        : double.NegativeInfinity;
+                    var high = idx < row.Count - 1
+                        ? placed[row[idx + 1].Name].X - b.Width - GapBetween(ctx.Kin, b, row[idx + 1])
+                        : double.PositiveInfinity;
+
+                    var x = Math.Min(Math.Max(target.Value, low), high);
+                    if (Math.Abs(x - placed[b.Name].X) > 0.5)
+                    {
+                        placed[b.Name].X = x;
+                        moved = true;
+                    }
+                }
+            }
+
+            if (!moved)
+                break;
+        }
+    }
+
+    /// <summary>
+    /// The x this block's wires would put it at: the median of one target per wire,
+    /// which is the point that minimises their total horizontal run.
+    /// </summary>
+    private double? DesiredX(Blocks blocks, Dictionary<string, Placed> placed, Ctx ctx, Block block)
+    {
+        var order = block.Order ?? block.Members;
+        var targets = new List<double>();
+
+        // wires up to each member's own parents
+        for (var i = 0; i < order.Count; i++)
+        {
+            var rel = ctx.ParentRelOf.GetValueOrDefault(order[i]);
+            if (rel == null)
+                continue;
+
+            var u = UnionPoint(blocks, placed, rel);
+            if (u != null)
+                targets.Add(u.Value.X - i * (_cardWidth + _coupleGap) - _cardWidth / 2);
+        }
+
+        // wires down from each of the block's own unions to their children
+        foreach (var r in block.Relations)
+        {
+            var ia = order.IndexOf(r.From);
+            var ib = order.IndexOf(r.To);
+            if (ia < 0 && ib < 0)
+                continue;
+
+            var offset = ia >= 0 && ib >= 0
+                ? (ia + ib) / 2.0 * (_cardWidth + _coupleGap) + _cardWidth / 2
+                : Math.Max(ia, ib) * (_cardWidth + _coupleGap) + _cardWidth / 2;
+
+            foreach (var kid in ctx.Kids.GetValueOrDefault(r.Id) ?? [])
+            {
+                var c = CardCentre(blocks, placed, kid);
+                if (c != null)
+                    targets.Add(c.Value.X - offset);
+            }
+        }
+
+        if (targets.Count == 0)
+            return null;
+
+        targets.Sort();
+        var mid = targets.Count >> 1;
+        return targets.Count % 2 == 1
+            ? targets[mid]
+            : (targets[mid - 1] + targets[mid]) / 2;
+    }
+
+    /// <summary>
+    /// Chooses, for every block, which of its candidate arrangements puts the fewest
+    /// long horizontal runs on the wires around it.
+    /// </summary>
+    private void PickMemberOrders(Blocks blocks, Dictionary<string, Placed> placed, Ctx ctx)
+    {
+        foreach (var block in blocks.List)
+            block.Order = block.Orders[0];
+
+        // Two sweeps are enough: the first fixes each block against its neighbours'
+        // default arrangement, the second against their chosen one.
+        for (var pass = 0; pass < 2; pass++)
+        {
+            foreach (var b in blocks.List)
+            {
+                if (b.Orders.Count < 2 || !placed.ContainsKey(b.Name))
+                    continue;
+
+                var bestOrder = b.Order;
+                var bestCost = double.PositiveInfinity;
+
+                foreach (var candidate in b.Orders)
+                {
+                    b.Order = candidate;
+                    var c = LocalCost(blocks, placed, ctx, b);
+                    if (c < bestCost)
+                    {
+                        bestCost = c;
+                        bestOrder = candidate;
+                    }
+                }
+
+                b.Order = bestOrder;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Where a person's card lands, given the current arrangement of its block.
+    /// </summary>
+    private Point? CardCentre(Blocks blocks, Dictionary<string, Placed> placed, string personId)
+    {
+        var root = blocks.BlockOf.GetValueOrDefault(personId);
+        if (root == null || !blocks.ById.TryGetValue(root, out var block))
+            return null;
+
+        if (!placed.TryGetValue(block.Name, out var p))
+            return null;
+
+        var order = block.Order ?? block.Members;
+        var idx = order.IndexOf(personId);
+        if (idx < 0)
+            return null;
+
+        return new Point(p.X + idx * (_cardWidth + _coupleGap) + _cardWidth / 2, p.Y);
+    }
+
+    /// <summary>
+    /// Horizontal run of every wire touching the given block.
+    /// </summary>
+    private double LocalCost(Blocks blocks, Dictionary<string, Placed> placed, Ctx ctx, Block block)
+    {
+        var total = 0d;
+        foreach (var rel in block.Relations)
+            total += UnionCost(blocks, placed, ctx, rel);
+
+        // marriages of the block's members that live in some other block cannot
+        // happen - a marriage always merges both spouses into one block - so the
+        // only other wires are the ones down to this block's members' own parents.
+        var order = block.Order ?? block.Members;
+        foreach (var member in order)
+        {
+            var rel = ctx.ParentRelOf.GetValueOrDefault(member);
+            if (rel == null)
+                continue;
+
+            var u = UnionPoint(blocks, placed, rel);
+            var c = CardCentre(blocks, placed, member);
+            if (u != null && c != null)
+                total += Math.Abs(u.Value.X - c.Value.X);
+        }
+
+        return total;
+    }
+
+    private Point? UnionPoint(Blocks blocks, Dictionary<string, Placed> placed, TreeRelationVM rel)
+    {
+        var a = CardCentre(blocks, placed, rel.From);
+        var b = CardCentre(blocks, placed, rel.To);
+        var one = a ?? b;
+        if (one == null)
+            return null;
+
+        var x = a != null && b != null ? (a.Value.X + b.Value.X) / 2 : one.Value.X;
+        var y = (a != null && b != null ? Math.Max(a.Value.Y, b.Value.Y) : one.Value.Y) + _cardHeight + UnionDrop;
+        return new Point(x, y);
+    }
+
+    /// <summary>
+    /// Horizontal run of the marriage wires and the descent wires of one union.
+    /// </summary>
+    private double UnionCost(Blocks blocks, Dictionary<string, Placed> placed, Ctx ctx, TreeRelationVM rel)
+    {
+        var u = UnionPoint(blocks, placed, rel);
+        if (u == null)
+            return 0;
+
+        var total = 0d;
+        var a = CardCentre(blocks, placed, rel.From);
+        var b = CardCentre(blocks, placed, rel.To);
+        if (a != null)
+            total += Math.Abs(a.Value.X - u.Value.X);
+        if (b != null)
+            total += Math.Abs(b.Value.X - u.Value.X);
+
+        foreach (var kid in ctx.Kids.GetValueOrDefault(rel.Id) ?? [])
+        {
+            var c = CardCentre(blocks, placed, kid);
+            if (c != null)
+                total += Math.Abs(c.Value.X - u.Value.X);
+        }
+
+        return total;
+    }
+
+    /// <summary>
+    /// Turns block rectangles plus chosen arrangements into per-person boxes.
+    /// </summary>
+    private Dictionary<string, Rect> Expand(Blocks blocks, Dictionary<string, Placed> placed, IReadOnlyList<TreeRelationVM> relations)
+    {
+        var pos = new Dictionary<string, Rect>();
+
+        foreach (var block in blocks.List)
+        {
+            if (!placed.TryGetValue(block.Name, out var p))
+                continue;
+
+            var order = block.Order ?? block.Members;
+            var x = p.X;
+            foreach (var member in order)
+            {
+                pos[member] = new Rect { X = x, Y = p.Y, Width = _cardWidth, Height = _cardHeight };
+                x += _cardWidth + _coupleGap;
+            }
+        }
+
+        // The union point sits centred between the two spouses, just below their row.
+        foreach (var rel in relations)
+        {
+            var a = pos.GetValueOrDefault(rel.From);
+            var b = pos.GetValueOrDefault(rel.To);
+            var one = a ?? b;
+            if (one == null)
+                continue;
+
+            var cxu = a != null && b != null
+                ? (a.X + a.Width / 2 + b.X + b.Width / 2) / 2
+                : one.X + one.Width / 2;
+            var cyu = (a != null && b != null ? Math.Max(a.Y, b.Y) : one.Y) + _cardHeight + UnionDrop;
+
+            pos[rel.Id] = new Rect { X = cxu - 0.5, Y = cyu - 0.5, Width = 1, Height = 1 };
+        }
+
+        return pos;
+    }
+
+    /// <summary>
+    /// How tangled a candidate layout is: horizontal wire run, plus its width.
+    /// </summary>
+    private static double Score(Dictionary<string, Rect> pos, IReadOnlyList<TreeRelationVM> relations, Ctx ctx)
+    {
+        var total = 0d;
+
+        foreach (var rel in relations)
+        {
+            var u = pos.GetValueOrDefault(rel.Id);
+            if (u == null)
+                continue;
+
+            var ux = u.X + 0.5;
+
+            var a = pos.GetValueOrDefault(rel.From);
+            var b = pos.GetValueOrDefault(rel.To);
+            if (a != null)
+                total += Math.Abs(a.X + a.Width / 2 - ux);
+            if (b != null)
+                total += Math.Abs(b.X + b.Width / 2 - ux);
+
+            foreach (var kid in ctx.Kids.GetValueOrDefault(rel.Id) ?? [])
+            {
+                var c = pos.GetValueOrDefault(kid);
+                if (c == null)
+                    continue;
+
+                total += Math.Abs(c.X + c.Width / 2 - ux) + Math.Abs(c.Y - u.Y);
+            }
+        }
+
+        var minX = double.PositiveInfinity;
+        var maxX = double.NegativeInfinity;
+        foreach (var p in pos.Values)
+        {
+            if (p.X < minX)
+                minX = p.X;
+            if (p.X + p.Width > maxX)
+                maxX = p.X + p.Width;
+        }
+
+        return total + WidthWeight * (maxX - minX);
+    }
+
+    #endregion
+
+    #region Finishing touches
+
+    /// <summary>
+    /// Slides each union point sideways to line up with its children.
+    ///
+    /// The point starts centred between the two spouses, so unless the children
+    /// happen to be centred there too the descent wire leaves with a short sideways
+    /// jog - and a jog of a dozen pixels reads as a kink rather than as a step.
+    ///
+    /// The point is free to sit anywhere between the two cards' centres: it lives
+    /// below both cards, so even at the extremes it only turns one marriage wire
+    /// into a straight drop and lengthens the other. That trade is worth it - on the
+    /// reference tree this both removes every sub-40px kink and shortens the total
+    /// wire run. Runs after the search, on the winning layout only; the search itself
+    /// keeps the simpler centred model, which this can only improve on.
+    /// </summary>
+    private void AlignUnions(Dictionary<string, Rect> pos, IReadOnlyList<TreeRelationVM> relations, Ctx ctx)
+    {
+        foreach (var rel in relations)
+        {
+            var u = pos.GetValueOrDefault(rel.Id);
+            var a = pos.GetValueOrDefault(rel.From);
+            var b = pos.GetValueOrDefault(rel.To);
+            if (u == null || a == null || b == null)
+                continue;
+
+            var sum = 0d;
+            var n = 0;
+            foreach (var kid in ctx.Kids.GetValueOrDefault(rel.Id) ?? [])
+            {
+                var c = pos.GetValueOrDefault(kid);
+                if (c == null)
+                    continue;
+
+                sum += c.X + c.Width / 2;
+                n++;
+            }
+
+            if (n == 0)
+                continue;
+
+            var lo = Math.Min(a.X, b.X) + _cardWidth / 2;   // centre of the left card
+            var hi = Math.Max(a.X, b.X) + _cardWidth / 2;   // centre of the right card
+            if (hi < lo)
+                continue;                                   // spouses not side by side
+
+            u.X = Math.Min(Math.Max(sum / n, lo), hi) - u.Width / 2;
+        }
+    }
+
+    private static void Normalize(Dictionary<string, Rect> pos)
+    {
+        var minX = double.PositiveInfinity;
+        var minY = double.PositiveInfinity;
+
+        foreach (var p in pos.Values)
+        {
+            if (p.X < minX)
+                minX = p.X;
+            if (p.Y < minY)
+                minY = p.Y;
+        }
+
+        if (double.IsInfinity(minX))
+            return;
+
+        foreach (var p in pos.Values)
+        {
+            p.X -= minX - Spacing;
+            p.Y -= minY - Spacing;
+        }
+    }
+
+    private static (long Width, long Height) Measure(Dictionary<string, Rect> pos)
+    {
+        var maxX = 0d;
+        var maxY = 0d;
+
+        foreach (var p in pos.Values)
+        {
+            if (p.X + p.Width > maxX)
+                maxX = p.X + p.Width;
+            if (p.Y + p.Height > maxY)
+                maxY = p.Y + p.Height;
+        }
+
+        return ((long)Math.Ceiling(maxX + Spacing), (long)Math.Ceiling(maxY + Spacing));
+    }
+
+    private static JArray BuildChildren(IReadOnlyList<TreePersonVM> persons, IReadOnlyList<TreeRelationVM> relations, Dictionary<string, Rect> pos)
+    {
+        var children = new JArray();
+
+        foreach (var person in persons)
+        {
+            var p = pos.GetValueOrDefault(person.Id);
+            if (p == null)
+                continue;
+
+            children.Add(new JObject
+            {
+                ["id"] = person.Id,
+                ["label"] = person.Name,
+                ["x"] = p.X,
+                ["y"] = p.Y,
+                ["width"] = p.Width,
+                ["height"] = p.Height,
+                ["info"] = JObject.FromObject(person)
+            });
+        }
+
+        // Union nodes carry no `info`, which is how the front-end tells them apart
+        // from cards (see convertPersons / detectChildren in tree.js).
+        foreach (var rel in relations)
+        {
+            var u = pos.GetValueOrDefault(rel.Id);
+            if (u == null)
+                continue;
+
+            children.Add(new JObject
+            {
+                ["id"] = rel.Id,
+                ["x"] = u.X,
+                ["y"] = u.Y,
+                ["width"] = 1,
+                ["height"] = 1
+            });
+        }
+
+        return children;
+    }
+
+    /// <summary>
+    /// Mirrors the finished layout around the horizontal axis of the canvas.
+    ///
+    /// The whole layout is built top-down - dot ranks parents above children, the
+    /// marriage brackets hang below the cards, the sibling buses run above them - so
+    /// bottom-to-top is a mirror of the finished geometry rather than a second layout
+    /// mode. Every wire is orthogonal, so mirroring leaves the corners square, and
+    /// the cards themselves are only moved, never turned over.
+    /// </summary>
+    private static void FlipVertical(JObject tree, double height)
+    {
+        foreach (var child in (JArray)tree["children"])
+            child["y"] = height - (child["y"].Value<double>() + child["height"].Value<double>());
+
+        foreach (var edge in (JArray)tree["edges"])
+        {
+            var section = (JObject)((JArray)edge["sections"])[0];
+            section["startPoint"]["y"] = height - section["startPoint"]["y"].Value<double>();
+            section["endPoint"]["y"] = height - section["endPoint"]["y"].Value<double>();
+
+            foreach (var bend in (JArray)section["bendPoints"])
+                bend["y"] = height - bend["y"].Value<double>();
+        }
+    }
+
+    #endregion
+
+    #region Routing
+
+    /// <summary>
+    /// Groups cards into per-row bands, so trunks can be steered around them.
+    /// </summary>
+    private static List<Band> BuildBands(Dictionary<string, Rect> pos, IReadOnlyList<TreePersonVM> persons)
+    {
+        var rows = new Dictionary<double, Band>();
+
+        foreach (var person in persons)
+        {
+            var p = pos.GetValueOrDefault(person.Id);
+            if (p == null)
+                continue;
+
+            var key = JsRound(p.Y);
+            if (!rows.TryGetValue(key, out var band))
+                rows[key] = band = new Band { Y1 = p.Y, Y2 = p.Y + p.Height };
+
+            if (p.Y + p.Height > band.Y2)
+                band.Y2 = p.Y + p.Height;
+
+            band.Spans.Add(new Span(person.Id, p.X, p.X + p.Width));
+        }
+
+        var bands = rows.Values.OrderBy(x => x.Y1).ToList();
+        for (var i = 0; i < bands.Count; i++)
+        {
+            bands[i].Spans = bands[i].Spans.OrderBy(x => x.X1).ToList();
+            bands[i].Index = i;
+        }
+
+        return bands;
+    }
+
+    /// <summary>
+    /// Index of the row a card row's y belongs to, which is also the number of the
+    /// band directly above it.
+    /// </summary>
+    private static int RowIndex(List<Band> bands, double rowY)
+    {
+        for (var i = 0; i < bands.Count; i++)
+        {
+            if (Math.Abs(bands[i].Y1 - rowY) < 0.5)
+                return i;
+        }
+
+        return 0;
+    }
+
+    private static bool IsFree(Band band, double x, string exceptId)
+    {
+        foreach (var s in band.Spans)
+        {
+            if (s.Id == exceptId)
+                continue;
+
+            if (x > s.X1 && x < s.X2)
+                return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Nearest x to wantX that clears every card in the band.
+    /// </summary>
+    private static double FreeX(Band band, double wantX, string exceptId)
+    {
+        var spans = band.Spans.Where(x => x.Id != exceptId).ToList();
+        if (spans.Count == 0 || IsFree(band, wantX, exceptId))
+            return wantX;
+
+        var gaps = new List<(double From, double To)>
+        {
+            (double.NegativeInfinity, spans[0].X1 - CardClearance)
+        };
+
+        for (var i = 1; i < spans.Count; i++)
+        {
+            var from = spans[i - 1].X2 + CardClearance;
+            var to = spans[i].X1 - CardClearance;
+            if (to > from)
+                gaps.Add((from, to));
+        }
+
+        gaps.Add((spans[^1].X2 + CardClearance, double.PositiveInfinity));
+
+        var best = wantX;
+        var bestDist = double.PositiveInfinity;
+        foreach (var gap in gaps)
+        {
+            var c = Math.Min(Math.Max(wantX, gap.From), gap.To);
+            var d = Math.Abs(c - wantX);
+            if (d < bestDist)
+            {
+                bestDist = d;
+                best = c;
+            }
+        }
+
+        return best;
+    }
+
+    /// <summary>
+    /// Walks a trunk down from (x, yFrom) to yTo, stepping sideways into a gap
+    /// whenever a row of cards is in the way: a line may cross another line, but
+    /// never a card.
+    /// </summary>
+    private static List<Point> Descend(List<Band> bands, LaneMap lanes, double x, double yFrom, double yTo, double wantX, string exceptId)
+    {
+        var pts = new List<Point> { new(x, yFrom) };
+        var cur = x;
+
+        foreach (var band in bands)
+        {
+            if (band.Y2 <= yFrom + 0.5 || band.Y1 >= yTo - 0.5)
+                continue;
+
+            if (IsFree(band, cur, exceptId))
+                continue;
+
+            // The dodge runs just above the row it is getting past, which is the
+            // same shelf the sibling buses of that row live on - so it queues for a
+            // lane there like they do.
+            var lane = FreeX(band, wantX, exceptId);
+            var laneY = band.Y1 - lanes.Offset(lanes.Take(band.Index, true, cur, lane));
+            pts.Add(new Point(cur, laneY));
+            pts.Add(new Point(lane, laneY));
+            cur = lane;
+        }
+
+        pts.Add(new Point(cur, yTo));
+        return pts;
+    }
+
+    private JArray RouteEdges(IReadOnlyList<TreePersonVM> persons, IReadOnlyList<TreeRelationVM> relations, Dictionary<string, Rect> pos, List<Band> bands, LaneMap lanes)
+    {
+        var edges = new JArray();
+
+        // --- marriage lines: person -> union ---------------------------------
+        // Someone with several marriages gets one exit port per marriage, spread
+        // across the bottom of the card and ordered by which side the union is on.
+        var bySpouse = new Dictionary<string, List<TreeRelationVM>>();
+        var spouseOrder = new List<string>();
+
+        void PushSpouse(string personId, TreeRelationVM rel)
+        {
+            if (!pos.ContainsKey(personId) || !pos.ContainsKey(rel.Id))
+                return;
+
+            if (!bySpouse.TryGetValue(personId, out var list))
+            {
+                bySpouse[personId] = list = [];
+                spouseOrder.Add(personId);
+            }
+
+            list.Add(rel);
+        }
+
+        foreach (var rel in relations)
+        {
+            PushSpouse(rel.From, rel);
+            PushSpouse(rel.To, rel);
+        }
+
+        var ports = new Dictionary<(string Person, string Rel), double>();
+
+        foreach (var personId in spouseOrder)
+        {
+            var card = pos[personId];
+            var rels = bySpouse[personId].OrderBy(x => pos[x.Id].X).ToList();
+            bySpouse[personId] = rels;
+
+            var usable = card.Width - _portInset * 2;
+            for (var j = 0; j < rels.Count; j++)
+            {
+                ports[(personId, rels[j].Id)] = rels.Count == 1
+                    ? card.X + card.Width / 2
+                    : card.X + _portInset + usable * (j + 1) / (rels.Count + 1);
+            }
+        }
+
+        // The union point hangs in the band under the lower of the two spouses, and
+        // the bracket that reaches it is a horizontal run like any other - so the
+        // bracket queues for a lane in that band and the point settles at whatever
+        // height the lane it got sits at. Two brackets that used to merge into one
+        // line (a marriage reaching across an intervening card, or one drawn down
+        // from the row above) now sit a lane apart.
+        foreach (var rel in relations)
+        {
+            var u = pos.GetValueOrDefault(rel.Id);
+            var a = pos.GetValueOrDefault(rel.From);
+            var b = pos.GetValueOrDefault(rel.To);
+            var one = a ?? b;
+            if (u == null || one == null)
+                continue;
+
+            var rowY = a != null && b != null ? Math.Max(a.Y, b.Y) : one.Y;
+            var ux = u.X + u.Width / 2;
+            var from = ux;
+            var to = ux;
+
+            if (a != null && ports.TryGetValue((rel.From, rel.Id), out var pa))
+                (from, to) = (Math.Min(from, pa), Math.Max(to, pa));
+
+            if (b != null && ports.TryGetValue((rel.To, rel.Id), out var pb))
+                (from, to) = (Math.Min(from, pb), Math.Max(to, pb));
+
+            var lane = lanes.Take(RowIndex(bands, rowY) + 1, false, from, to);
+            u.Y = rowY + _cardHeight + lanes.Offset(lane) - u.Height / 2;
+        }
+
+        foreach (var personId in spouseOrder)
+        {
+            var card = pos[personId];
+
+            foreach (var rel in bySpouse[personId])
+            {
+                var px = ports[(personId, rel.Id)];
+                var u = pos[rel.Id];
+                var ux = u.X + u.Width / 2;
+                var uy = u.Y + u.Height / 2;
+
+                List<Point> pts;
+                if (uy >= card.Y + card.Height)
+                {
+                    pts = Descend(bands, lanes, px, card.Y + card.Height, uy, ux, personId);
+                    pts.Add(new Point(ux, uy));
+                }
+                else
+                {
+                    pts = [new Point(px, card.Y), new Point(px, uy), new Point(ux, uy)];
+                }
+
+                // The wire stops exactly on the union point, so the front-end must
+                // not trim its last segment - doing so would leave a childless
+                // marriage as two stubs that never meet.
+                edges.Add(MakeEdge(rel.Id + ":" + personId, personId, rel.Id + ":n", pts));
+            }
+        }
+
+        // --- descent lines: union -> children --------------------------------
+        var byUnion = new Dictionary<string, List<TreePersonVM>>();
+        var unionOrder = new List<string>();
+
+        foreach (var person in persons)
+        {
+            if (person.Parents == null || !pos.ContainsKey(person.Parents) || !pos.ContainsKey(person.Id))
+                continue;
+
+            if (!byUnion.TryGetValue(person.Parents, out var list))
+            {
+                byUnion[person.Parents] = list = [];
+                unionOrder.Add(person.Parents);
+            }
+
+            list.Add(person);
+        }
+
+        foreach (var unionId in unionOrder)
+        {
+            var un = pos[unionId];
+            var unx = un.X + un.Width / 2;
+            var uny = un.Y + un.Height / 2;
+
+            // Children that ended up on different rows each get their own bus; a
+            // single shared bus would leave the lower ones hanging off a drop that
+            // has to cross whatever sits in between.
+            var rowsOf = new Dictionary<double, List<TreePersonVM>>();
+            foreach (var kid in byUnion[unionId])
+            {
+                var rowKey = JsRound(pos[kid.Id].Y);
+                if (!rowsOf.TryGetValue(rowKey, out var list))
+                    rowsOf[rowKey] = list = [];
+
+                list.Add(kid);
+            }
+
+            foreach (var rowKey in rowsOf.Keys.OrderBy(x => x))
+            {
+                var group = rowsOf[rowKey];
+                var rowY = pos[group[0].Id].Y;
+
+                var centre = group.Sum(x => pos[x.Id].X + _cardWidth / 2) / group.Count;
+                var leftmost = group.Min(x => pos[x.Id].X + _cardWidth / 2);
+                var rightmost = group.Max(x => pos[x.Id].X + _cardWidth / 2);
+
+                // The trunk is walked down to the base lane first: which rows it has
+                // to get past does not depend on the lane the bus ends up in, and
+                // where the trunk lands is one end of the run the bus has to cover.
+                var trunk = Descend(bands, lanes, unx, uny, Math.Max(rowY - LaneStep, uny), centre, null);
+                var landing = trunk[^1].X;
+
+                // The sideways step of a lone child lands halfway down the band, one
+                // LaneStep below the union and one above the card, so it reads as a
+                // deliberate step rather than a notch against the card. Where two
+                // buses of the same row cover the same stretch of x - two unrelated
+                // couples whose descents reach across one another - they go on
+                // different shelves, so the pair never reads as one sibling bus.
+                var lane = lanes.Take(RowIndex(bands, rowY), true, Math.Min(landing, leftmost), Math.Max(landing, rightmost));
+                var busY = Math.Max(rowY - lanes.Offset(lane), uny);
+                trunk[^1] = new Point(landing, busY);
+
+                foreach (var child in group)
+                {
+                    var cp = pos[child.Id];
+                    var ccx = cp.X + cp.Width / 2;
+
+                    var pts = new List<Point>(trunk) { new(ccx, busY), new(ccx, cp.Y) };
+                    edges.Add(MakeEdge(child.Id + ":" + unionId, unionId + ":s", child.Id + ":n", pts));
+                }
+            }
+        }
+
+        return edges;
+    }
+
+    /// <summary>
+    /// Pushes the rows apart until every band is deep enough for the lanes the probe
+    /// pass asked for.
+    ///
+    /// A band needs one LaneStep of clearance below the cards above it, one for each
+    /// marriage bracket lane, one for each sibling bus lane, and one between the two
+    /// families of lanes. For a band holding a single bracket lane and a single bus
+    /// lane that is exactly the RowGap dot already left, so a tree with no overlapping
+    /// runs does not grow at all. Every row below a band that has to open up moves
+    /// down with it; the union points are left alone, the routing pass recomputes
+    /// them from the cards.
+    /// </summary>
+    private void ExpandRows(Dictionary<string, Rect> pos, IReadOnlyList<TreePersonVM> persons, List<Band> bands, LaneMap lanes)
+    {
+        var shift = new Dictionary<double, double>();
+        var total = 0d;
+
+        for (var i = 0; i < bands.Count; i++)
+        {
+            if (i > 0)
+            {
+                var gap = bands[i].Y1 - bands[i - 1].Y2;
+                var need = (lanes.Count(i, false) + lanes.Count(i, true) + 1) * LaneStep;
+                if (need > gap)
+                    total += need - gap;
+            }
+
+            shift[JsRound(bands[i].Y1)] = total;
+        }
+
+        if (total == 0)
+            return;
+
+        foreach (var person in persons)
+        {
+            var p = pos.GetValueOrDefault(person.Id);
+            if (p != null && shift.TryGetValue(JsRound(p.Y), out var delta))
+                p.Y += delta;
+        }
+    }
+
+    /// <summary>
+    /// Packs a polyline into the section shape the front-end expects.
+    /// </summary>
+    private static JObject MakeEdge(string id, string source, string target, List<Point> points)
+    {
+        var clean = new List<Point>();
+        foreach (var point in points)
+        {
+            if (clean.Count == 0 || clean[^1] != point)
+                clean.Add(point);
+        }
+
+        if (clean.Count < 2)
+            clean.Add(clean[0]);
+
+        // Drop points that sit on the straight line between their neighbours: the
+        // trunk builder emits one per row it walks past, and a redundant bend makes
+        // a straight run look like a decision.
+        for (var k = clean.Count - 2; k > 0; k--)
+        {
+            var prev = clean[k - 1];
+            var cur = clean[k];
+            var next = clean[k + 1];
+
+            if ((prev.X == cur.X && cur.X == next.X) || (prev.Y == cur.Y && cur.Y == next.Y))
+                clean.RemoveAt(k);
+        }
+
+        var bends = new JArray();
+        for (var j = 1; j < clean.Count - 1; j++)
+            bends.Add(new JObject { ["x"] = clean[j].X, ["y"] = clean[j].Y });
+
+        return new JObject
+        {
+            ["id"] = id,
+            ["sources"] = new JArray(source),
+            ["targets"] = new JArray(target),
+            ["info"] = new JObject { ["fakeTarget"] = false },
+            ["sections"] = new JArray(new JObject
+            {
+                ["id"] = id + "_s0",
+                ["startPoint"] = new JObject { ["x"] = clean[0].X, ["y"] = clean[0].Y },
+                ["endPoint"] = new JObject { ["x"] = clean[^1].X, ["y"] = clean[^1].Y },
+                ["bendPoints"] = bends
+            })
+        };
+    }
+
+    #endregion
+
+    #region Helpers
+
+    /// <summary>
+    /// Rounds the way JavaScript's Math.round does - halves go up, not to even -
+    /// because the row keys and the gap constants are derived from it.
+    /// </summary>
+    private static double JsRound(double value)
+    {
+        return Math.Floor(value + 0.5);
+    }
+
+    /// <summary>
+    /// The mulberry32 generator, so the shuffled declaration orders are the same
+    /// on every run and on every machine.
+    /// </summary>
+    private sealed class Mulberry32
+    {
+        public Mulberry32(uint seed)
+        {
+            _state = seed;
+        }
+
+        private uint _state;
+
+        public double Next()
+        {
+            unchecked
+            {
+                _state += 0x6D2B79F5;
+                var a = _state;
+
+                // Math.imul(a ^ (a >>> 15), 1 | a): the low 32 bits of the product.
+                var t = (uint)((int)(a ^ (a >> 15)) * (int)(1 | a));
+
+                var inner = (uint)((int)(t ^ (t >> 7)) * (int)(61 | t));
+                t = (t + inner) ^ t;
+
+                return (t ^ (t >> 14)) / 4294967296d;
+            }
+        }
+    }
+
+    #endregion
+
+    #region Types
+
+    private class Block
+    {
+        public string Id { get; init; }
+        public string Name { get; init; }
+        public List<string> Members { get; set; } = [];
+        public List<TreeRelationVM> Relations { get; } = [];
+        public double Width { get; set; }
+        public List<List<string>> Orders { get; set; }
+        public List<string> Order { get; set; }
+    }
+
+    private class Blocks
+    {
+        public List<Block> List { get; init; }
+        public Dictionary<string, Block> ById { get; init; }
+        public Dictionary<string, Block> ByName { get; init; }
+        public Dictionary<string, string> BlockOf { get; init; }
+    }
+
+    private class Ctx
+    {
+        public List<Link> Links { get; init; }
+        public Dictionary<string, List<string>> Kids { get; init; }
+        public Dictionary<string, TreeRelationVM> RelById { get; init; }
+        public HashSet<string> Kin { get; set; }
+        public Dictionary<string, TreeRelationVM> ParentRelOf { get; set; }
+    }
+
+    private readonly record struct Link(string From, string To);
+
+    private readonly record struct Point(double X, double Y);
+
+    private class Placed
+    {
+        public double X { get; set; }
+        public double Y { get; set; }
+    }
+
+    private class Rect
+    {
+        public double X { get; set; }
+        public double Y { get; set; }
+        public double Width { get; init; }
+        public double Height { get; init; }
+    }
+
+    private class Band
+    {
+        public int Index { get; set; }
+        public double Y1 { get; init; }
+        public double Y2 { get; set; }
+        public List<Span> Spans { get; set; } = [];
+    }
+
+    /// <summary>
+    /// Keeps two horizontal runs from landing on top of one another.
+    ///
+    /// Every horizontal run of every wire lives in one of the bands between two rows
+    /// of cards, and a band carries two families of them: the marriage brackets just
+    /// under the parents, and the sibling buses just over the children (a trunk that
+    /// steps sideways to get past a row uses that row's bus shelf). A family used to
+    /// be a single y, so two runs whose x ranges overlapped came out as one line -
+    /// and one line under two adjacent cards reads as a sibling bus, which is how a
+    /// husband and wife end up looking like a brother and sister. This hands each run
+    /// a lane number instead: the lowest one whose runs all clear it sideways.
+    /// </summary>
+    private sealed class LaneMap
+    {
+        private const double Eps = 1;   // runs that merely touch are not a problem
+
+        private readonly Dictionary<(int Band, bool Bus), List<List<(double From, double To)>>> _groups = new();
+
+        /// <summary>
+        /// Probe pass: still count the lanes, but report every one of them at the
+        /// base offset, so the lanes are measured on the geometry dot produced rather
+        /// than on a half-expanded version of it.
+        /// </summary>
+        public bool Flat { get; init; }
+
+        /// <summary>
+        /// Claims a lane for a run covering [x1, x2] and returns its lane number.
+        /// </summary>
+        public int Take(int band, bool bus, double x1, double x2)
+        {
+            var from = Math.Min(x1, x2);
+            var to = Math.Max(x1, x2);
+
+            // Nothing is drawn, so nothing can be mistaken for a bus, and the lane it
+            // nominally sits in stays free for a run that is actually visible.
+            if (to - from <= Eps)
+                return 0;
+
+            if (!_groups.TryGetValue((band, bus), out var lanes))
+                _groups[(band, bus)] = lanes = [];
+
+            for (var i = 0; i < lanes.Count; i++)
+            {
+                if (lanes[i].Any(x => from < x.To - Eps && to > x.From + Eps))
+                    continue;
+
+                lanes[i].Add((from, to));
+                return i;
+            }
+
+            lanes.Add([(from, to)]);
+            return lanes.Count - 1;
+        }
+
+        /// <summary>
+        /// How many lanes one family of runs in one band ended up needing.
+        /// </summary>
+        public int Count(int band, bool bus) => _groups.GetValueOrDefault((band, bus))?.Count ?? 0;
+
+        /// <summary>
+        /// How far from the edge of the band a lane hangs.
+        /// </summary>
+        public double Offset(int lane) => Flat ? LaneStep : LaneStep * (1 + lane);
+    }
+
+    private readonly record struct Span(string Id, double X1, double X2);
+
+    #endregion
+}

--- a/src/Bonsai/Areas/Admin/Logic/Tree/TreeLayoutJob.FullTree.cs
+++ b/src/Bonsai/Areas/Admin/Logic/Tree/TreeLayoutJob.FullTree.cs
@@ -5,7 +5,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Bonsai.Areas.Admin.ViewModels.Tree;
 using Bonsai.Code.DomainModel.Relations;
-using Bonsai.Code.Utils;
 using Bonsai.Data;
 using Bonsai.Data.Models;
 using Impworks.Utils.Linq;
@@ -24,13 +23,12 @@ public partial class TreeLayoutJob
             return;
 
         var trees = GetAllSubtrees(ctx);
-        var thoroughness = GetThoroughness();
 
         _logger.Information($"Full tree layout started: {ctx.Pages.Count} people, {ctx.Relations.Count} rels, {trees.Count} subtrees.");
 
         foreach (var tree in trees)
         {
-            var rendered = await RenderTreeAsync(tree, thoroughness, token);
+            var rendered = await RenderTreeAsync(tree, true, token);
             var layout = new TreeLayout
             {
                 Id = Guid.NewGuid(),
@@ -67,19 +65,6 @@ public partial class TreeLayoutJob
         }
 
         return result;
-    }
-
-    /// <summary>
-    /// Returns interpolated thoroughness.
-    /// </summary>
-    private int GetThoroughness()
-    {
-        return Interpolator.MapValue(
-            _config.TreeRenderThoroughness,
-            new IntervalMap(1, 10, 1, 10),
-            new IntervalMap(11, 50, 11, 600),
-            new IntervalMap(51, 100, 601, 15000)
-        );
     }
 
     #endregion

--- a/src/Bonsai/Areas/Admin/Logic/Tree/TreeLayoutJob.PartialTrees.cs
+++ b/src/Bonsai/Areas/Admin/Logic/Tree/TreeLayoutJob.PartialTrees.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Bonsai.Areas.Admin.ViewModels.Tree;
 using Bonsai.Code.DomainModel.Relations;
+using Bonsai.Code.Services.Graphviz;
 using Bonsai.Data.Models;
 using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json;
@@ -45,7 +46,7 @@ public partial class TreeLayoutJob
                     Kind = kind
                 });
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not GraphvizNotFoundException)
             {
                 var json = JsonConvert.SerializeObject(tree);
                 _logger.Error(ex.Demystify(), $"Failed to render partial tree ({kind}) for page {page.Id}:\n{json}");

--- a/src/Bonsai/Areas/Admin/Logic/Tree/TreeLayoutJob.PartialTrees.cs
+++ b/src/Bonsai/Areas/Admin/Logic/Tree/TreeLayoutJob.PartialTrees.cs
@@ -34,7 +34,7 @@ public partial class TreeLayoutJob
 
             try
             {
-                var rendered = await RenderTreeAsync(tree, 1000, token);
+                var rendered = await RenderTreeAsync(tree, false, token);
 
                 layouts.Add(new TreeLayout
                 {

--- a/src/Bonsai/Areas/Admin/Logic/Tree/TreeLayoutJob.cs
+++ b/src/Bonsai/Areas/Admin/Logic/Tree/TreeLayoutJob.cs
@@ -52,14 +52,27 @@ public partial class TreeLayoutJob: JobBase
     }
 
     /// <summary>
-    /// Renders the tree using ELK.js.
+    /// Renders the tree using Graphviz.
     /// </summary>
-    protected async Task<string> RenderTreeAsync(TreeLayoutVM tree, int thoroughness, CancellationToken token)
+    /// <param name="tree">Tree contents.</param>
+    /// <param name="exhaustive">
+    /// Search over many declaration orders and keep the tidiest layout.
+    /// Only worth the time for the full tree: the partial trees are simple enough
+    /// for Graphviz to get right on the first try, and there is one per page.
+    /// </param>
+    /// <param name="token">Cancellation token.</param>
+    protected async Task<string> RenderTreeAsync(TreeLayoutVM tree, bool exhaustive, CancellationToken token)
     {
         var json = JsonConvert.SerializeObject(tree);
+        var options = new
+        {
+            direction = _config.TreeDirection.ToString(),
+            view = _config.TreeViewMode.ToString()
+        };
+
         var result = await _js.InvokeFromFileAsync<string>(
             "./External/tree/tree-layout.js",
-            args: [json, thoroughness],
+            args: [json, exhaustive, options],
             cancellationToken: token
         );
 

--- a/src/Bonsai/Areas/Admin/Logic/Tree/TreeLayoutJob.cs
+++ b/src/Bonsai/Areas/Admin/Logic/Tree/TreeLayoutJob.cs
@@ -14,25 +14,23 @@ using Bonsai.Data.Models;
 using Bonsai.Localization;
 using Impworks.Utils.Linq;
 using Impworks.Utils.Strings;
-using Jering.Javascript.NodeJS;
 using Microsoft.EntityFrameworkCore;
-using Newtonsoft.Json;
 using Serilog;
 
 namespace Bonsai.Areas.Admin.Logic.Tree;
 
 public partial class TreeLayoutJob: JobBase
 {
-    public TreeLayoutJob(AppDbContext db, INodeJSService js, BonsaiConfigService config, ILogger logger)
+    public TreeLayoutJob(AppDbContext db, TreeLayoutEngine engine, BonsaiConfigService config, ILogger logger)
     {
         _db = db;
-        _js = js;
+        _engine = engine;
         _config = config.GetDynamicConfig();
         _logger = logger;
     }
 
     private readonly AppDbContext _db;
-    private readonly INodeJSService _js;
+    private readonly TreeLayoutEngine _engine;
     private readonly DynamicConfig _config;
     private readonly ILogger _logger;
 
@@ -63,17 +61,12 @@ public partial class TreeLayoutJob: JobBase
     /// <param name="token">Cancellation token.</param>
     protected async Task<string> RenderTreeAsync(TreeLayoutVM tree, bool exhaustive, CancellationToken token)
     {
-        var json = JsonConvert.SerializeObject(tree);
-        var options = new
-        {
-            direction = _config.TreeDirection.ToString(),
-            view = _config.TreeViewMode.ToString()
-        };
-
-        var result = await _js.InvokeFromFileAsync<string>(
-            "./External/tree/tree-layout.js",
-            args: [json, exhaustive, options],
-            cancellationToken: token
+        var result = await _engine.LayoutAsync(
+            tree,
+            exhaustive,
+            _config.TreeDirection,
+            _config.TreeViewMode,
+            token
         );
 
         if (string.IsNullOrEmpty(result) || result == "null")

--- a/src/Bonsai/Areas/Admin/ViewModels/DynamicConfig/UpdateDynamicConfigVM.cs
+++ b/src/Bonsai/Areas/Admin/ViewModels/DynamicConfig/UpdateDynamicConfigVM.cs
@@ -47,6 +47,16 @@ public class UpdateDynamicConfigVM: IMapped
     public TreeKind[] TreeKinds { get; set; }
 
     /// <summary>
+    /// The vertical direction in which trees are laid out.
+    /// </summary>
+    public TreeDirection TreeDirection { get; set; }
+
+    /// <summary>
+    /// The look of the cards in a tree.
+    /// </summary>
+    public TreeViewMode TreeViewMode { get; set; }
+
+    /// <summary>
     /// Flag indicating whether the MCP server is enabled for AI agent access.
     /// </summary>
     public bool McpEnabled { get; set; }
@@ -60,6 +70,8 @@ public class UpdateDynamicConfigVM: IMapped
               .Map(x => x.TreeRenderThoroughness, x => x.TreeRenderThoroughness)
               .Map(x => x.HideBlackRibbon, x => x.HideBlackRibbon)
               .Map(x => x.TreeKinds, x => x.TreeKinds == null ? 0 : x.TreeKinds.Aggregate((TreeKind)0, (a, b) => a | b))
+              .Map(x => x.TreeDirection, x => x.TreeDirection)
+              .Map(x => x.TreeViewMode, x => x.TreeViewMode)
               .Map(x => x.McpEnabled, x => x.McpEnabled);
 
         config.NewConfig<Code.Services.Config.DynamicConfig, UpdateDynamicConfigVM>()
@@ -69,6 +81,8 @@ public class UpdateDynamicConfigVM: IMapped
               .Map(x => x.TreeRenderThoroughness, x => x.TreeRenderThoroughness)
               .Map(x => x.HideBlackRibbon, x => x.HideBlackRibbon)
               .Map(x => x.TreeKinds, x => Enum.GetValues<TreeKind>().Where(y => x.TreeKinds.HasFlag(y)).ToArray())
+              .Map(x => x.TreeDirection, x => x.TreeDirection)
+              .Map(x => x.TreeViewMode, x => x.TreeViewMode)
               .Map(x => x.McpEnabled, x => x.McpEnabled);
     }
 }

--- a/src/Bonsai/Areas/Admin/ViewModels/DynamicConfig/UpdateDynamicConfigVM.cs
+++ b/src/Bonsai/Areas/Admin/ViewModels/DynamicConfig/UpdateDynamicConfigVM.cs
@@ -36,12 +36,6 @@ public class UpdateDynamicConfigVM: IMapped
     public bool HideBlackRibbon { get; set; }
 
     /// <summary>
-    /// Tree render thoroughness coefficient.
-    /// </summary>
-    [Range(1, 100, ErrorMessageResourceType = typeof(Texts), ErrorMessageResourceName = "Admin_DynamicConfig_Validation_ThoroughnessRange")]
-    public int TreeRenderThoroughness { get; set; }
-
-    /// <summary>
     /// Kinds of tree which should be rendered automatically.
     /// </summary>
     public TreeKind[] TreeKinds { get; set; }
@@ -67,7 +61,6 @@ public class UpdateDynamicConfigVM: IMapped
               .Map(x => x.Title, x => x.Title)
               .Map(x => x.AllowGuests, x => x.AllowGuests)
               .Map(x => x.AllowRegistration, x => x.AllowRegistration)
-              .Map(x => x.TreeRenderThoroughness, x => x.TreeRenderThoroughness)
               .Map(x => x.HideBlackRibbon, x => x.HideBlackRibbon)
               .Map(x => x.TreeKinds, x => x.TreeKinds == null ? 0 : x.TreeKinds.Aggregate((TreeKind)0, (a, b) => a | b))
               .Map(x => x.TreeDirection, x => x.TreeDirection)
@@ -78,7 +71,6 @@ public class UpdateDynamicConfigVM: IMapped
               .Map(x => x.Title, x => x.Title)
               .Map(x => x.AllowGuests, x => x.AllowGuests)
               .Map(x => x.AllowRegistration, x => x.AllowRegistration)
-              .Map(x => x.TreeRenderThoroughness, x => x.TreeRenderThoroughness)
               .Map(x => x.HideBlackRibbon, x => x.HideBlackRibbon)
               .Map(x => x.TreeKinds, x => Enum.GetValues<TreeKind>().Where(y => x.TreeKinds.HasFlag(y)).ToArray())
               .Map(x => x.TreeDirection, x => x.TreeDirection)

--- a/src/Bonsai/Areas/Admin/Views/DynamicConfig/Index.cshtml
+++ b/src/Bonsai/Areas/Admin/Views/DynamicConfig/Index.cshtml
@@ -114,7 +114,7 @@
                     </div>
                 </div>
                 <div class="form-group row">
-                    <label class="col-sm-3">@Texts.Admin_Config_Other</label>
+                    <label class="col-sm-3"></label>
                     <div class="col-sm-9">
                         <div class="custom-control custom-checkbox">
                             <input type="checkbox" asp-for="HideBlackRibbon" class="custom-control-input" id="HideBlackRibbon" />

--- a/src/Bonsai/Areas/Admin/Views/DynamicConfig/Index.cshtml
+++ b/src/Bonsai/Areas/Admin/Views/DynamicConfig/Index.cshtml
@@ -18,98 +18,137 @@
     <div class="col-md-9 col-sm-12">
         <form action="@Url.Action("Update")" method="post">
 
-            <div class="form-group row">
-                <label class="col-sm-3 col-form-label">@Texts.Admin_Config_Caption</label>
-                <div class="col-sm-9">
-                    <input asp-for="Title" class="form-control" />
-                    <span class="small text-muted">@Texts.Admin_Config_CaptionDescription</span>
-                    <span asp-validation-for="Title" class="text-danger"></span>
-                </div>
-            </div>
-            <div class="form-group row">
-                <label class="col-sm-3">@Texts.Admin_Config_Access</label>
-                <div class="col-sm-9">
-                    <div class="custom-control custom-radio">
-                        <input type="radio" asp-for="AllowGuests" value="True" class="custom-control-input" id="AllowGuestsTrue" />
-                        <label class="custom-control-label" for="AllowGuestsTrue">
-                            @Texts.Admin_Config_Access_AnyCanRead
-                        </label>
-                    </div>
-                    <div class="custom-control custom-radio">
-                        <input type="radio" asp-for="AllowGuests" value="False" class="custom-control-input" id="AllowGuestsFalse" />
-                        <label class="custom-control-label" for="AllowGuestsFalse">
-                            @Texts.Admin_Config_Access_RegisteredCanRead
-                        </label>
+            <div class="config-section">
+                <h4>@Texts.Admin_Config_Section_Main</h4>
+
+                <div class="form-group row">
+                    <label class="col-sm-3 col-form-label">@Texts.Admin_Config_Caption</label>
+                    <div class="col-sm-9">
+                        <input asp-for="Title" class="form-control" />
+                        <span class="small text-muted">@Texts.Admin_Config_CaptionDescription</span>
+                        <span asp-validation-for="Title" class="text-danger"></span>
                     </div>
                 </div>
-            </div>
-            <div class="form-group row">
-                <label class="col-sm-3">@Texts.Admin_Config_Registration</label>
-                <div class="col-sm-9">
-                    <div class="custom-control custom-radio">
-                        <input type="radio" asp-for="AllowRegistration" value="True" class="custom-control-input" id="AllowRegistrationTrue" />
-                        <label class="custom-control-label" for="AllowRegistrationTrue">
-                            @Texts.Admin_Config_Registration_Enabled
-                        </label>
-                    </div>
-                    <div class="custom-control custom-radio">
-                        <input type="radio" asp-for="AllowRegistration" value="False" class="custom-control-input" id="AllowRegistrationFalse" />
-                        <label class="custom-control-label" for="AllowRegistrationFalse">
-                            @Texts.Admin_Config_Registration_Disabled
-                        </label>
-                    </div>
-                </div>
-            </div>
-            <div class="form-group row">
-                <label class="col-sm-3">@Texts.Admin_Config_TreeKinds</label>
-                <div class="col-sm-9">
-                    @{ TreeKindOption(TreeKind.FullTree, Texts.Admin_Config_TreeKinds_FullTree, Texts.Admin_Config_TreeKinds_FullTreeDescription); }
-                    @{ TreeKindOption(TreeKind.CloseFamily, Texts.Admin_Config_TreeKinds_CloseFamily, Texts.Admin_Config_TreeKinds_CloseFamilyDescription); }
-                    @{ TreeKindOption(TreeKind.Ancestors, Texts.Admin_Config_TreeKinds_Ancestors, Texts.Admin_Config_TreeKinds_AncestorsDescription); }
-                    @{ TreeKindOption(TreeKind.Descendants, Texts.Admin_Config_TreeKinds_Descendants, Texts.Admin_Config_TreeKinds_DescendantsDescription); }
-                </div>
-            </div>
-            <div class="form-group row">
-                <label class="col-sm-3">@Texts.Admin_Config_TreeDisplay</label>
-                <div class="col-sm-9">
-                    <div class="mb-2">
-                        <input asp-for="TreeRenderThoroughness" type="range" min="1" max="100" class="form-control"/>
-                        <div class="small text-muted">
-                            <div class="pull-left">@Texts.Admin_Config_TreeDisplay_FastAndRough</div>
-                            <div class="pull-right">@Texts.Admin_Config_TreeDisplay_SlowAndThorough</div>
-                            <div class="clearfix"></div>
+                <div class="form-group row">
+                    <label class="col-sm-3">@Texts.Admin_Config_Access</label>
+                    <div class="col-sm-9">
+                        <div class="custom-control custom-radio">
+                            <input type="radio" asp-for="AllowGuests" value="True" class="custom-control-input" id="AllowGuestsTrue" />
+                            <label class="custom-control-label" for="AllowGuestsTrue">
+                                @Texts.Admin_Config_Access_AnyCanRead
+                            </label>
                         </div>
-                        <span asp-validation-for="TreeRenderThoroughness" class="text-danger"></span>
-                    </div>
-                    <div class="custom-control custom-checkbox">
-                        <input type="checkbox" asp-for="HideBlackRibbon" class="custom-control-input" id="HideBlackRibbon" />
-                        <label class="custom-control-label" for="HideBlackRibbon">
-                            @Texts.Admin_Config_TreeDisplay_HideBlackRibbon
-                        </label>
+                        <div class="custom-control custom-radio">
+                            <input type="radio" asp-for="AllowGuests" value="False" class="custom-control-input" id="AllowGuestsFalse" />
+                            <label class="custom-control-label" for="AllowGuestsFalse">
+                                @Texts.Admin_Config_Access_RegisteredCanRead
+                            </label>
+                        </div>
                     </div>
                 </div>
-            </div>
-            
-            <div class="form-group row">
-                <label class="col-sm-3">@Texts.Admin_Config_Mcp</label>
-                <div class="col-sm-9">
-                    <div class="custom-control custom-checkbox">
-                        <input type="checkbox" asp-for="McpEnabled" class="custom-control-input" id="McpEnabled" />
-                        <label class="custom-control-label" for="McpEnabled">
-                            @Texts.Admin_Config_Mcp_Enabled<br />
-                            <small class="text-muted">@Texts.Admin_Config_Mcp_EnabledDescription</small>
-                        </label>
+                <div class="form-group row">
+                    <label class="col-sm-3">@Texts.Admin_Config_Registration</label>
+                    <div class="col-sm-9">
+                        <div class="custom-control custom-radio">
+                            <input type="radio" asp-for="AllowRegistration" value="True" class="custom-control-input" id="AllowRegistrationTrue" />
+                            <label class="custom-control-label" for="AllowRegistrationTrue">
+                                @Texts.Admin_Config_Registration_Enabled
+                            </label>
+                        </div>
+                        <div class="custom-control custom-radio">
+                            <input type="radio" asp-for="AllowRegistration" value="False" class="custom-control-input" id="AllowRegistrationFalse" />
+                            <label class="custom-control-label" for="AllowRegistrationFalse">
+                                @Texts.Admin_Config_Registration_Disabled
+                            </label>
+                        </div>
                     </div>
                 </div>
             </div>
 
-            <div class="form-group row">
-                <div class="col-sm-3">@Texts.Admin_Config_Version</div>
-                <div class="col-sm-9 text-muted">
-                    <small>
-                        @Texts.Admin_Config_Version_Build: @(StringHelper.Coalesce(config.BuildCommit, @Texts.Admin_Config_Version_BuildUnknown))<br />
-                        @Texts.Admin_Config_Version_Database: @(config.ConnectionStrings.UseEmbeddedDatabase ? "SQLite" : "PostgreSQL")
-                    </small>
+            <div class="config-section">
+                <h4>@Texts.Admin_Config_Section_Tree</h4>
+
+                <div class="form-group row">
+                    <label class="col-sm-3">@Texts.Admin_Config_TreeKinds</label>
+                    <div class="col-sm-9">
+                        @{ TreeKindOption(TreeKind.FullTree, Texts.Admin_Config_TreeKinds_FullTree, Texts.Admin_Config_TreeKinds_FullTreeDescription); }
+                        @{ TreeKindOption(TreeKind.CloseFamily, Texts.Admin_Config_TreeKinds_CloseFamily, Texts.Admin_Config_TreeKinds_CloseFamilyDescription); }
+                        @{ TreeKindOption(TreeKind.Ancestors, Texts.Admin_Config_TreeKinds_Ancestors, Texts.Admin_Config_TreeKinds_AncestorsDescription); }
+                        @{ TreeKindOption(TreeKind.Descendants, Texts.Admin_Config_TreeKinds_Descendants, Texts.Admin_Config_TreeKinds_DescendantsDescription); }
+                    </div>
+                </div>
+                <div class="form-group row">
+                    <label class="col-sm-3">@Texts.Admin_Config_TreeDirection</label>
+                    <div class="col-sm-9">
+                        <div class="custom-control custom-radio">
+                            <input type="radio" asp-for="TreeDirection" value="@TreeDirection.TopToBottom" class="custom-control-input" id="TreeDirectionTopToBottom" />
+                            <label class="custom-control-label" for="TreeDirectionTopToBottom">
+                                @Texts.Admin_Config_TreeDirection_TopToBottom <br/>
+                                <small class="text-muted">@Texts.Admin_Config_TreeDirection_TopToBottomDescription</small>
+                            </label>
+                        </div>
+                        <div class="custom-control custom-radio">
+                            <input type="radio" asp-for="TreeDirection" value="@TreeDirection.BottomToTop" class="custom-control-input" id="TreeDirectionBottomToTop" />
+                            <label class="custom-control-label" for="TreeDirectionBottomToTop">
+                                @Texts.Admin_Config_TreeDirection_BottomToTop <br/>
+                                <small class="text-muted">@Texts.Admin_Config_TreeDirection_BottomToTopDescription</small>
+                            </label>
+                        </div>
+                    </div>
+                </div>
+                <div class="form-group row">
+                    <label class="col-sm-3">@Texts.Admin_Config_TreeView</label>
+                    <div class="col-sm-9">
+                        <div class="custom-control custom-radio">
+                            <input type="radio" asp-for="TreeViewMode" value="@TreeViewMode.Default" class="custom-control-input" id="TreeViewModeDefault" />
+                            <label class="custom-control-label" for="TreeViewModeDefault">
+                                @Texts.Admin_Config_TreeView_Default
+                            </label>
+                        </div>
+                        <div class="custom-control custom-radio">
+                            <input type="radio" asp-for="TreeViewMode" value="@TreeViewMode.Compact" class="custom-control-input" id="TreeViewModeCompact" />
+                            <label class="custom-control-label" for="TreeViewModeCompact">
+                                @Texts.Admin_Config_TreeView_Compact
+                            </label>
+                        </div>
+                    </div>
+                </div>
+                <div class="form-group row">
+                    <label class="col-sm-3">@Texts.Admin_Config_Other</label>
+                    <div class="col-sm-9">
+                        <div class="custom-control custom-checkbox">
+                            <input type="checkbox" asp-for="HideBlackRibbon" class="custom-control-input" id="HideBlackRibbon" />
+                            <label class="custom-control-label" for="HideBlackRibbon">
+                                @Texts.Admin_Config_TreeDisplay_HideBlackRibbon
+                            </label>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="config-section">
+                <h4>@Texts.Admin_Config_Other</h4>
+
+                <div class="form-group row">
+                    <label class="col-sm-3">@Texts.Admin_Config_Mcp</label>
+                    <div class="col-sm-9">
+                        <div class="custom-control custom-checkbox">
+                            <input type="checkbox" asp-for="McpEnabled" class="custom-control-input" id="McpEnabled" />
+                            <label class="custom-control-label" for="McpEnabled">
+                                @Texts.Admin_Config_Mcp_Enabled<br />
+                                <small class="text-muted">@Texts.Admin_Config_Mcp_EnabledDescription</small>
+                            </label>
+                        </div>
+                    </div>
+                </div>
+                <div class="form-group row">
+                    <div class="col-sm-3">@Texts.Admin_Config_Version</div>
+                    <div class="col-sm-9 text-muted">
+                        <small>
+                            @Texts.Admin_Config_Version_Build: @(StringHelper.Coalesce(config.BuildCommit, @Texts.Admin_Config_Version_BuildUnknown))<br />
+                            @Texts.Admin_Config_Version_Database: @(config.ConnectionStrings.UseEmbeddedDatabase ? "SQLite" : "PostgreSQL")
+                        </small>
+                    </div>
                 </div>
             </div>
 

--- a/src/Bonsai/Areas/Common/Styles/Components/admin/admin.scss
+++ b/src/Bonsai/Areas/Common/Styles/Components/admin/admin.scss
@@ -91,6 +91,21 @@
         }
     }
 
+    // A settings form is a long list of unrelated switches, so it is broken into
+    // titled sections with a rule between them.
+    .config-section {
+        margin-bottom: 1.5rem;
+
+        h4 {
+            margin-bottom: 1rem;
+        }
+
+        & + .config-section {
+            border-top: 1px solid #e2e2e2;
+            padding-top: 1.5rem;
+        }
+    }
+
     .form-label-required {
         &::after {
             display: inline-block;

--- a/src/Bonsai/Areas/Common/Styles/Components/front/tree.scss
+++ b/src/Bonsai/Areas/Common/Styles/Components/front/tree.scss
@@ -106,6 +106,47 @@
             }
         }
 
+        // The compact view: the layout hands out cards half as wide and a little
+        // shorter, so the contents have to give up their breathing room. The photo
+        // keeps 2px around it and shrinks to a thumbnail, which leaves the name
+        // enough width to stay readable; what still does not fit is clipped
+        // rather than wrapped out of the card.
+        &.compact .tree-card-wrapper {
+            &.deceased:before {
+                height: 6px;
+                width: 36px;
+                top: 3px;
+                left: -7px;
+            }
+
+            .tree-card {
+                border-radius: 4px;
+                padding: 2px;
+                overflow: hidden;
+
+                .tree-card-photo {
+                    width: 48px;
+                    height: 48px;
+                    border-radius: 2px;
+                    margin-right: 4px;
+                }
+
+                .tree-card-body {
+                    overflow: hidden;
+
+                    .tree-card-title {
+                        font-size: 12px;
+                        margin-bottom: 2px;
+                        max-height: 52px;
+                    }
+
+                    .tree-card-date {
+                        font-size: 10px;
+                    }
+                }
+            }
+        }
+
         .tree-back {
             polyline {
                 fill: transparent;

--- a/src/Bonsai/Areas/Common/Styles/Components/front/tree.scss
+++ b/src/Bonsai/Areas/Common/Styles/Components/front/tree.scss
@@ -138,6 +138,11 @@
                         font-size: 12px;
                         margin-bottom: 2px;
                         max-height: 52px;
+
+                        // the initials wrap as a whole, never between themselves
+                        .tree-card-initials {
+                            white-space: nowrap;
+                        }
                     }
 
                     .tree-card-date {

--- a/src/Bonsai/Areas/Front/Scripts/tree.js
+++ b/src/Bonsai/Areas/Front/Scripts/tree.js
@@ -16,10 +16,38 @@
             },
             displayName: function () {
                 // a compact card has no room for the whole name, so it shows the
-                // short form and keeps the full one in the tooltip
+                // surname only and keeps the full one in the tooltip
                 return this.compact
-                    ? abbreviateName(this.value.info.Name)
+                    ? getSurname(this.value.info.Name)
                     : this.value.info.Name;
+            },
+            displayInitials: function () {
+                // the initials are rendered separately, because they must not be
+                // broken apart by a line wrap
+                return this.compact
+                    ? getInitials(this.value.info.Name)
+                    : null;
+            },
+            dates: function () {
+                // a compact card only has room for the years, and it drops them
+                // altogether when nothing is known
+                var info = this.value.info;
+                return this.compact
+                    ? formatDates(getYear(info.Birth), getYear(info.Death))
+                    : formatDates(info.Birth, info.Death);
+            },
+            tooltip: function () {
+                // the compact card is abbreviated, so the tooltip carries the
+                // full name and the full dates
+                if (!this.compact) {
+                    return null;
+                }
+
+                var info = this.value.info;
+                var dates = formatDates(info.Birth, info.Death);
+                return dates
+                    ? this.fullName + '\n' + dates
+                    : this.fullName;
             }
         }
     });
@@ -96,19 +124,51 @@
         return tree.children.filter(function (x) { return !!x.info; });
     }
 
-    function abbreviateName(name) {
+    function splitName(name) {
+        return (name || '').split(' ').filter(function (x) { return x.length > 0; });
+    }
+
+    function getSurname(name) {
+        // "Горбунов Дмитрий Владимирович" -> "Горбунов"
+        var parts = splitName(name);
+        return parts.length < 2 ? name : parts[0];
+    }
+
+    function getInitials(name) {
         // shortens everything after the surname to an initial:
-        // "Горбунов Дмитрий Владимирович" -> "Горбунов Д. В."
-        var parts = (name || '').split(' ').filter(function (x) { return x.length > 0; });
+        // "Горбунов Дмитрий Владимирович" -> "Д. В."
+        var parts = splitName(name);
         if (parts.length < 2) {
-            return name;
+            return null;
         }
 
-        var initials = parts.slice(1).map(function (x) {
-            return x.charAt(0).toUpperCase() + '.';
-        });
+        return parts.slice(1)
+                    .map(function (x) { return x.charAt(0).toUpperCase() + '.'; })
+                    .join(' ');
+    }
 
-        return [parts[0]].concat(initials).join(' ');
+    function getYear(date) {
+        // returns the year component of a short date ("12/03/1980" -> "1980"),
+        // or nothing at all when the year is unknown
+        if (!date) {
+            return null;
+        }
+
+        var year = date.split('/').pop();
+        return year.indexOf('?') === 0 ? null : year;
+    }
+
+    function formatDates(birth, death) {
+        // renders the lifespan; either of the dates may be missing
+        if (birth && death) {
+            return birth + ' — ' + death;
+        }
+
+        if (death) {
+            return '— ' + death;
+        }
+
+        return birth || null;
     }
 
     function convertEdges(tree, direction) {

--- a/src/Bonsai/Areas/Front/Scripts/tree.js
+++ b/src/Bonsai/Areas/Front/Scripts/tree.js
@@ -6,7 +6,22 @@
 
     Vue.component('tree-card', {
         template: '#tree-card-template',
-        props: ['value', 'active']
+        props: ['value', 'active', 'compact'],
+        computed: {
+            fullName: function () {
+                var info = this.value.info;
+                return info.MaidenName
+                    ? info.Name + ' (' + info.MaidenName + ')'
+                    : info.Name;
+            },
+            displayName: function () {
+                // a compact card has no room for the whole name, so it shows the
+                // short form and keeps the full one in the tooltip
+                return this.compact
+                    ? abbreviateName(this.value.info.Name)
+                    : this.value.info.Name;
+            }
+        }
     });
 
     $trees.each(function () {
@@ -17,10 +32,15 @@
         var kind = $wrap.data('kind');
         var url = '/util/tree/' + encodeURIComponent(key) + '?kind=' + encodeURIComponent(kind);
 
-        requestTreeInfo($wrap, url, 0);
+        var view = {
+            direction: $wrap.data('direction'),
+            compact: $wrap.data('view') === 'Compact'
+        };
+
+        requestTreeInfo($wrap, url, view, 0);
     });
 
-    function requestTreeInfo($wrap, url, retryCount) {
+    function requestTreeInfo($wrap, url, view, retryCount) {
         if (retryCount > 10) {
             var $tree = $wrap.closest('.tree');
             $tree.find('.tree-preloader').remove();
@@ -31,27 +51,27 @@
         $.ajax(url)
             .then(function(data) {
                 if (data && data.content) {
-                    renderTree($wrap, data);
+                    renderTree($wrap, data, view);
                     return;
                 }
 
                 setTimeout(
                     function () {
-                        requestTreeInfo($wrap, url, retryCount + 1);
+                        requestTreeInfo($wrap, url, view, retryCount + 1);
                     },
                     5000
                 );
             }, function () {
-                requestTreeInfo($wrap, url, 11);
+                requestTreeInfo($wrap, url, view, 11);
             });
     }
 
-    function renderTree($wrap, treeInfo) {
+    function renderTree($wrap, treeInfo, view) {
         // displays the tree
         var tree = treeInfo.content;
         var rootId = treeInfo.rootId;
         var persons = convertPersons(tree);
-        var edges = convertEdges(tree);
+        var edges = convertEdges(tree, view.direction);
         var vue = new Vue({
             el: $wrap[0],
             data: {
@@ -59,7 +79,8 @@
                 edges: edges,
                 width: tree.width,
                 height: tree.height,
-                root: rootId
+                root: rootId,
+                compact: view.compact
             },
             mounted: function () {
                 var $view = $(this.$el);
@@ -75,8 +96,26 @@
         return tree.children.filter(function (x) { return !!x.info; });
     }
 
-    function convertEdges(tree) {
+    function abbreviateName(name) {
+        // shortens everything after the surname to an initial:
+        // "Горбунов Дмитрий Владимирович" -> "Горбунов Д. В."
+        var parts = (name || '').split(' ').filter(function (x) { return x.length > 0; });
+        if (parts.length < 2) {
+            return name;
+        }
+
+        var initials = parts.slice(1).map(function (x) {
+            return x.charAt(0).toUpperCase() + '.';
+        });
+
+        return [parts[0]].concat(initials).join(' ');
+    }
+
+    function convertEdges(tree, direction) {
         // returns the SVG-friendly list of edges
+        // a wire ends on the border of a card, so the last point is nudged one
+        // pixel into it - which is upwards when the tree grows from the bottom up
+        var nudge = direction === 'BottomToTop' ? -1 : 1;
         var hasChildren = detectChildren(tree);
         var result = [];
         for (var idx = 0; idx < tree.edges.length; idx++) {
@@ -93,8 +132,8 @@
             }
             if (!edgeInfo.info.fakeTarget || hasChildren[edgeInfo.targets[0]]) {
                 // omit the last segment if the marriage has no children (avoids dangling connector)
-                // +1 to account for a pseudo-node's height (avoids gaps)
-                points.push(e.x, e.y + 1);
+                // the nudge accounts for a pseudo-node's height (avoids gaps)
+                points.push(e.x, e.y + nudge);
             }
             result.push({
                 // +0.5 for crispy clear nodes

--- a/src/Bonsai/Areas/Front/Views/Tree/Main.cshtml
+++ b/src/Bonsai/Areas/Front/Views/Tree/Main.cshtml
@@ -1,5 +1,6 @@
 @using Bonsai.Areas.Front.ViewModels.Page
 @using Bonsai.Code.Services.Config
+@using Bonsai.Data.Models
 @using Bonsai.Localization
 @inject BonsaiConfigService ConfigService
 @model PageTreeVM
@@ -12,11 +13,11 @@
 }
 
 <div class="tree">
-    <div class="tree-wrapper" data-key="@Model.Key" data-kind="@Model.TreeKind">
+    <div class="tree-wrapper @(cfg.TreeViewMode == TreeViewMode.Compact ? "compact" : null)" data-key="@Model.Key" data-kind="@Model.TreeKind" data-direction="@cfg.TreeDirection" data-view="@cfg.TreeViewMode">
         <svg class="tree-back" :width="width" :height="height">
             <polyline :points="e.points" v-for="e in edges" />
         </svg>
-        <tree-card v-for="p in persons" :key="p.id" :value="p" :active="p.id == root" />
+        <tree-card v-for="p in persons" :key="p.id" :value="p" :active="p.id == root" :compact="compact" />
     </div>
     <div class="tree-preloader">
         <h4>
@@ -32,12 +33,12 @@
 <script id="tree-card-template" type="text/x-template">
     <div :class="{'tree-card-wrapper': true, male: value.info.IsMale, female: !value.info.IsMale, deceased: @(cfg.HideBlackRibbon ? "false" : "value.info.IsDead"), active: active}"
          :style="{left: value.x, top: value.y, width: value.width, height: value.height}" :data-id="value.id">
-        <a :href="value.info.Url" class="tree-card" draggable="false" target="_top">
+        <a :href="value.info.Url" class="tree-card" draggable="false" target="_top" :title="compact ? fullName : null">
             <div class="tree-card-photo" :style="{'background-image': 'url(' + value.info.Photo + ')'}"></div>
             <div class="tree-card-body">
                 <span class="tree-card-title">
-                    {{value.info.Name}}
-                    <span v-if="value.info.MaidenName">({{value.info.MaidenName}})</span>
+                    {{displayName}}
+                    <span v-if="value.info.MaidenName && !compact">({{value.info.MaidenName}})</span>
                 </span>
                 <span class="tree-card-date">
                     <span>{{value.info.Birth}}</span>

--- a/src/Bonsai/Areas/Front/Views/Tree/Main.cshtml
+++ b/src/Bonsai/Areas/Front/Views/Tree/Main.cshtml
@@ -33,17 +33,15 @@
 <script id="tree-card-template" type="text/x-template">
     <div :class="{'tree-card-wrapper': true, male: value.info.IsMale, female: !value.info.IsMale, deceased: @(cfg.HideBlackRibbon ? "false" : "value.info.IsDead"), active: active}"
          :style="{left: value.x, top: value.y, width: value.width, height: value.height}" :data-id="value.id">
-        <a :href="value.info.Url" class="tree-card" draggable="false" target="_top" :title="compact ? fullName : null">
+        <a :href="value.info.Url" class="tree-card" draggable="false" target="_top" :title="tooltip">
             <div class="tree-card-photo" :style="{'background-image': 'url(' + value.info.Photo + ')'}"></div>
             <div class="tree-card-body">
                 <span class="tree-card-title">
                     {{displayName}}
+                    <span v-if="displayInitials" class="tree-card-initials">{{displayInitials}}</span>
                     <span v-if="value.info.MaidenName && !compact">({{value.info.MaidenName}})</span>
                 </span>
-                <span class="tree-card-date">
-                    <span>{{value.info.Birth}}</span>
-                    <span v-if="value.info.Death != null"> &mdash; {{value.info.Death}}</span>
-                </span>
+                <span class="tree-card-date" v-if="dates">{{dates}}</span>
             </div>
         </a>
     </div>

--- a/src/Bonsai/Bonsai.csproj
+++ b/src/Bonsai/Bonsai.csproj
@@ -52,7 +52,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="External\tree\" />
     <Folder Include="wwwroot\media\" />
   </ItemGroup>
 
@@ -65,7 +64,6 @@
     <PackageReference Include="Humanizer.Core" Version="2.14.1" />
     <PackageReference Include="Humanizer.Core.ru" Version="2.14.1" />
     <PackageReference Include="Impworks.Utils" Version="1.0.55" />
-    <PackageReference Include="Jering.Javascript.NodeJS" Version="7.0.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
     <PackageReference Include="Lucene.Net" Version="4.8.0-beta00007" />
     <PackageReference Include="Lucene.Net.Analysis.Common" Version="4.8.0-beta00007" />
@@ -167,12 +165,6 @@
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>
       <None Update="External\ffmpeg\swscale-5.dll">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </None>
-      <None Update="External\tree\viz.cjs">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </None>
-      <None Update="External\tree\tree-layout.js">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>
     </ItemGroup>

--- a/src/Bonsai/Bonsai.csproj
+++ b/src/Bonsai/Bonsai.csproj
@@ -169,13 +169,7 @@
       <None Update="External\ffmpeg\swscale-5.dll">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>
-      <None Update="External\tree\elk-api.js">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </None>
-      <None Update="External\tree\elk-worker.min.js">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </None>
-      <None Update="External\tree\elk.js">
+      <None Update="External\tree\viz.cjs">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>
       <None Update="External\tree\tree-layout.js">

--- a/src/Bonsai/Code/Config/Startup.Services.cs
+++ b/src/Bonsai/Code/Config/Startup.Services.cs
@@ -1,14 +1,14 @@
-﻿using System.Net;
-using Bonsai.Areas.Admin.Logic;
+﻿using Bonsai.Areas.Admin.Logic;
 using Bonsai.Areas.Admin.Logic.Changesets;
 using Bonsai.Areas.Admin.Logic.MediaHandlers;
+using Bonsai.Areas.Admin.Logic.Tree;
 using Bonsai.Areas.Admin.Logic.Validation;
 using Bonsai.Areas.Front.Logic;
 using Bonsai.Areas.Front.Logic.Auth;
 using Bonsai.Areas.Front.Logic.Relations;
 using Bonsai.Code.Services;
 using Bonsai.Code.Services.Config;
-using Jering.Javascript.NodeJS;
+using Bonsai.Code.Services.Graphviz;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -29,11 +29,9 @@ public partial class Startup
             x.MultipartBodyLengthLimit = int.MaxValue;
         });
 
-        services.AddNodeJS();
-        services.Configure<OutOfProcessNodeJSServiceOptions>(opts => opts.InvocationTimeoutMS = -1);
-        services.Configure<HttpNodeJSServiceOptions>(opts => opts.Version = HttpVersion.Version20);
-
         // common
+        services.AddSingleton<IGraphvizService, GraphvizService>();
+        services.AddTransient<TreeLayoutEngine>();
         services.AddScoped<MarkdownService>();
         services.AddSingleton<CacheService>();
         services.AddTransient<BonsaiConfigService>();

--- a/src/Bonsai/Code/Services/Config/BonsaiConfigService.cs
+++ b/src/Bonsai/Code/Services/Config/BonsaiConfigService.cs
@@ -58,21 +58,8 @@ public class BonsaiConfigService
     /// </summary>
     private DynamicConfig LoadDynamicConfig()
     {
-        var cfg = JsonConvert.DeserializeObject<DynamicConfig>(
+        return JsonConvert.DeserializeObject<DynamicConfig>(
             _context.DynamicConfig.First().Value
         );
-
-        ApplyDefaults(cfg);
-
-        return cfg;
-    }
-
-    /// <summary>
-    /// Sets default values to properties (for backwards compatibility).
-    /// </summary>
-    private void ApplyDefaults(DynamicConfig cfg)
-    {
-        if (cfg.TreeRenderThoroughness == 0)
-            cfg.TreeRenderThoroughness = 50;
     }
 }

--- a/src/Bonsai/Code/Services/Config/DynamicConfig.cs
+++ b/src/Bonsai/Code/Services/Config/DynamicConfig.cs
@@ -31,11 +31,6 @@ public class DynamicConfig
     public bool HideBlackRibbon { get; set; }
 
     /// <summary>
-    /// Tree render thoroughness coefficient.
-    /// </summary>
-    public int TreeRenderThoroughness { get; set; }
-
-    /// <summary>
     /// Allowed kinds of trees.
     /// </summary>
     public TreeKind TreeKinds { get; set; }

--- a/src/Bonsai/Code/Services/Config/DynamicConfig.cs
+++ b/src/Bonsai/Code/Services/Config/DynamicConfig.cs
@@ -41,6 +41,16 @@ public class DynamicConfig
     public TreeKind TreeKinds { get; set; }
 
     /// <summary>
+    /// The vertical direction in which trees are laid out.
+    /// </summary>
+    public TreeDirection TreeDirection { get; set; }
+
+    /// <summary>
+    /// The look of the cards in a tree.
+    /// </summary>
+    public TreeViewMode TreeViewMode { get; set; }
+
+    /// <summary>
     /// Flag indicating whether the MCP server is enabled for AI agent access.
     /// </summary>
     public bool McpEnabled { get; set; }

--- a/src/Bonsai/Code/Services/Graphviz/GraphvizLayout.cs
+++ b/src/Bonsai/Code/Services/Graphviz/GraphvizLayout.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+
+namespace Bonsai.Code.Services.Graphviz;
+
+/// <summary>
+/// The part of a Graphviz layout the tree builder actually needs: the canvas
+/// height and where each node landed.
+/// </summary>
+public class GraphvizLayout
+{
+    /// <summary>
+    /// Height of the drawing, in points.
+    /// </summary>
+    public double Height { get; init; }
+
+    /// <summary>
+    /// Node centres by node name, in points, measured from the bottom left.
+    /// </summary>
+    public IReadOnlyDictionary<string, GraphvizPoint> Nodes { get; init; }
+}
+
+/// <summary>
+/// A point in Graphviz coordinates.
+/// </summary>
+public readonly record struct GraphvizPoint(double X, double Y);

--- a/src/Bonsai/Code/Services/Graphviz/GraphvizNotFoundException.cs
+++ b/src/Bonsai/Code/Services/Graphviz/GraphvizNotFoundException.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace Bonsai.Code.Services.Graphviz;
+
+/// <summary>
+/// Thrown when the "dot" executable cannot be launched at all.
+/// This is a configuration problem rather than a problem with a particular
+/// graph, so there is no point in trying the next graph: everything that
+/// catches per-graph render errors must let this one through.
+/// </summary>
+public class GraphvizNotFoundException(string path, Exception inner)
+    : Exception($"Failed to launch Graphviz (\"{path}\"). Make sure Graphviz is installed and \"dot\" is available on PATH.", inner)
+{
+    /// <summary>
+    /// The path that was used to launch the executable.
+    /// </summary>
+    public string Path { get; } = path;
+}

--- a/src/Bonsai/Code/Services/Graphviz/GraphvizService.cs
+++ b/src/Bonsai/Code/Services/Graphviz/GraphvizService.cs
@@ -1,0 +1,209 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Newtonsoft.Json;
+
+namespace Bonsai.Code.Services.Graphviz;
+
+/// <summary>
+/// Runs the native Graphviz "dot" binary.
+/// </summary>
+public class GraphvizService: IGraphvizService
+{
+    public GraphvizService(IWebHostEnvironment env)
+    {
+        _env = env;
+    }
+
+    private readonly IWebHostEnvironment _env;
+    private string _dotPath;
+
+    /// <summary>
+    /// Lays out several DOT sources in a single "dot" invocation.
+    /// dot reads a stream of graphs from stdin and emits one JSON document per
+    /// graph, so a search over hundreds of candidate layouts costs one process
+    /// start instead of hundreds.
+    /// </summary>
+    public async Task<IReadOnlyList<GraphvizLayout>> RenderAsync(IReadOnlyList<string> sources, CancellationToken token)
+    {
+        if (sources.Count == 0)
+            return [];
+
+        var dotPath = GetDotPath();
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = dotPath,
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            StandardOutputEncoding = Encoding.UTF8,
+            StandardErrorEncoding = Encoding.UTF8
+        };
+        startInfo.ArgumentList.Add("-Tjson");
+
+        using var proc = new Process { StartInfo = startInfo };
+
+        try
+        {
+            proc.Start();
+        }
+        catch (Win32Exception ex)
+        {
+            // No executable, no point in being asked again for the next graph.
+            throw new GraphvizNotFoundException(dotPath, ex);
+        }
+
+        // stdin has to be filled while stdout is being drained: dot lays out and
+        // emits each graph as it reads it, and a full output pipe would otherwise
+        // deadlock against a full input one.
+        var feed = FeedAsync(proc, sources, token);
+        var errors = proc.StandardError.ReadToEndAsync(token);
+
+        List<GraphvizLayout> results;
+        try
+        {
+            results = Parse(proc.StandardOutput);
+        }
+        catch (JsonException ex)
+        {
+            await feed;
+            throw new Exception($"Failed to parse the Graphviz output: {await errors}", ex);
+        }
+
+        await feed;
+        await proc.WaitForExitAsync(token);
+
+        if (proc.ExitCode != 0)
+            throw new Exception($"Graphviz exited with code {proc.ExitCode}: {await errors}");
+
+        if (results.Count != sources.Count)
+            throw new Exception($"Graphviz returned {results.Count} layouts for {sources.Count} graphs: {await errors}");
+
+        return results;
+    }
+
+    #region Private helpers
+
+    /// <summary>
+    /// Writes every source into the process's stdin and closes it.
+    /// </summary>
+    private static async Task FeedAsync(Process proc, IReadOnlyList<string> sources, CancellationToken token)
+    {
+        try
+        {
+            foreach (var source in sources)
+            {
+                await proc.StandardInput.WriteAsync(source.AsMemory(), token);
+                await proc.StandardInput.WriteAsync('\n');
+            }
+        }
+        finally
+        {
+            proc.StandardInput.Close();
+        }
+    }
+
+    /// <summary>
+    /// Reads the concatenated JSON documents dot writes, one per graph.
+    /// </summary>
+    private static List<GraphvizLayout> Parse(TextReader output)
+    {
+        var results = new List<GraphvizLayout>();
+        var serializer = new JsonSerializer();
+
+        using var reader = new JsonTextReader(output) { SupportMultipleContent = true, CloseInput = false };
+        while (reader.Read())
+        {
+            if (reader.TokenType != JsonToken.StartObject)
+                continue;
+
+            var graph = serializer.Deserialize<DotGraph>(reader);
+            results.Add(Convert(graph));
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Picks the canvas height and the node centres out of a parsed graph.
+    /// </summary>
+    private static GraphvizLayout Convert(DotGraph graph)
+    {
+        var height = double.NaN;
+        var bb = (graph.Bb ?? "").Split(',');
+        if (bb.Length == 4)
+            height = ParseCoord(bb[3]);
+
+        var nodes = new Dictionary<string, GraphvizPoint>();
+        foreach (var obj in graph.Objects ?? [])
+        {
+            if (string.IsNullOrEmpty(obj.Name) || string.IsNullOrEmpty(obj.Pos))
+                continue;
+
+            var parts = obj.Pos.Split(',');
+            if (parts.Length < 2)
+                continue;
+
+            nodes[obj.Name] = new GraphvizPoint(ParseCoord(parts[0]), ParseCoord(parts[1]));
+        }
+
+        return new GraphvizLayout { Height = height, Nodes = nodes };
+    }
+
+    private static double ParseCoord(string value)
+    {
+        return double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var result)
+            ? result
+            : double.NaN;
+    }
+
+    /// <summary>
+    /// Returns the path to the "dot" executable.
+    /// A copy shipped next to the app wins, as with ffmpeg; otherwise it is
+    /// looked up on PATH, which is where the Docker image's package puts it.
+    /// </summary>
+    private string GetDotPath()
+    {
+        if (_dotPath != null)
+            return _dotPath;
+
+        var executable = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "dot.exe" : "dot";
+        var local = Path.Combine(_env.ContentRootPath, "External", "graphviz", executable);
+
+        return _dotPath = File.Exists(local) ? local : "dot";
+    }
+
+    #endregion
+
+    #region Parsed shape of dot's JSON output
+
+    private class DotGraph
+    {
+        [JsonProperty("bb")]
+        public string Bb { get; set; }
+
+        [JsonProperty("objects")]
+        public List<DotObject> Objects { get; set; }
+    }
+
+    private class DotObject
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("pos")]
+        public string Pos { get; set; }
+    }
+
+    #endregion
+}

--- a/src/Bonsai/Code/Services/Graphviz/IGraphvizService.cs
+++ b/src/Bonsai/Code/Services/Graphviz/IGraphvizService.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Bonsai.Code.Services.Graphviz;
+
+/// <summary>
+/// Lays out DOT graphs.
+/// </summary>
+public interface IGraphvizService
+{
+    /// <summary>
+    /// Lays out several DOT sources in one go and returns one result per source,
+    /// in the order the sources were given.
+    /// </summary>
+    Task<IReadOnlyList<GraphvizLayout>> RenderAsync(IReadOnlyList<string> sources, CancellationToken token);
+}

--- a/src/Bonsai/Code/Services/Jobs/BackgroundJobService.cs
+++ b/src/Bonsai/Code/Services/Jobs/BackgroundJobService.cs
@@ -44,7 +44,7 @@ public class BackgroundJobService: IHostedService, IBackgroundJobService
         await _startup.WaitForStartup();
 
         foreach (var def in await LoadPendingJobsAsync())
-            _ = ExecuteJobAsync(def);
+            StartJob(def);
     }
 
     /// <summary>
@@ -70,7 +70,7 @@ public class BackgroundJobService: IHostedService, IBackgroundJobService
         if(jb.IsSuperseding)
             Cancel(def.ResourceKey);
             
-        _ = ExecuteJobAsync(def); // sic! fire and forget
+        StartJob(def);
     }
 
     /// <summary>
@@ -92,6 +92,24 @@ public class BackgroundJobService: IHostedService, IBackgroundJobService
     #endregion
 
     #region Helpers
+
+    /// <summary>
+    /// Hands the job over to the thread pool and returns at once.
+    ///
+    /// Calling ExecuteJobAsync directly would not be enough: an async method runs
+    /// on the calling thread until its first genuine suspension, and a job whose
+    /// awaits all complete synchronously (Microsoft.Data.Sqlite is synchronous
+    /// throughout, and so is reading a child process's output) would run to
+    /// completion inside the request that started it.
+    /// </summary>
+    private void StartJob(JobDescriptor def)
+    {
+        // registered here rather than inside the job, so that a superseding job
+        // queued right after this one still sees it and cancels it
+        _jobs.TryAdd(def.JobStateId, def);
+
+        _ = Task.Run(() => ExecuteJobAsync(def));
+    }
 
     /// <summary>
     /// Loads all incomplete jobs from the database.
@@ -175,8 +193,6 @@ public class BackgroundJobService: IHostedService, IBackgroundJobService
     /// </summary>
     private async Task ExecuteJobAsync(JobDescriptor def)
     {
-        _jobs.TryAdd(def.JobStateId, def);
-            
         var success = false;
 
         try

--- a/src/Bonsai/Data/Models/TreeDirection.cs
+++ b/src/Bonsai/Data/Models/TreeDirection.cs
@@ -1,0 +1,17 @@
+﻿namespace Bonsai.Data.Models;
+
+/// <summary>
+/// The vertical direction in which a tree is laid out.
+/// </summary>
+public enum TreeDirection
+{
+    /// <summary>
+    /// Parents on top, children below them.
+    /// </summary>
+    TopToBottom = 0,
+
+    /// <summary>
+    /// Children on top, parents below them.
+    /// </summary>
+    BottomToTop = 1
+}

--- a/src/Bonsai/Data/Models/TreeViewMode.cs
+++ b/src/Bonsai/Data/Models/TreeViewMode.cs
@@ -1,0 +1,17 @@
+﻿namespace Bonsai.Data.Models;
+
+/// <summary>
+/// The look of the cards in a tree.
+/// </summary>
+public enum TreeViewMode
+{
+    /// <summary>
+    /// Full-sized cards.
+    /// </summary>
+    Default = 0,
+
+    /// <summary>
+    /// Half-width cards with tighter contents.
+    /// </summary>
+    Compact = 1
+}

--- a/src/Bonsai/Localization/Texts.Designer.cs
+++ b/src/Bonsai/Localization/Texts.Designer.cs
@@ -637,6 +637,15 @@ namespace Bonsai.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Прочее.
+        /// </summary>
+        public static string Admin_Config_Other {
+            get {
+                return ResourceManager.GetString("Admin_Config_Other", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Регистрация.
         /// </summary>
         public static string Admin_Config_Registration {
@@ -673,11 +682,74 @@ namespace Bonsai.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Главное.
+        /// </summary>
+        public static string Admin_Config_Section_Main {
+            get {
+                return ResourceManager.GetString("Admin_Config_Section_Main", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Фамильное древо.
+        /// </summary>
+        public static string Admin_Config_Section_Tree {
+            get {
+                return ResourceManager.GetString("Admin_Config_Section_Tree", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Настройки.
         /// </summary>
         public static string Admin_Config_Title {
             get {
                 return ResourceManager.GetString("Admin_Config_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Направление.
+        /// </summary>
+        public static string Admin_Config_TreeDirection {
+            get {
+                return ResourceManager.GetString("Admin_Config_TreeDirection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Снизу вверх.
+        /// </summary>
+        public static string Admin_Config_TreeDirection_BottomToTop {
+            get {
+                return ResourceManager.GetString("Admin_Config_TreeDirection_BottomToTop", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Дети над родителями.
+        /// </summary>
+        public static string Admin_Config_TreeDirection_BottomToTopDescription {
+            get {
+                return ResourceManager.GetString("Admin_Config_TreeDirection_BottomToTopDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Сверху вниз.
+        /// </summary>
+        public static string Admin_Config_TreeDirection_TopToBottom {
+            get {
+                return ResourceManager.GetString("Admin_Config_TreeDirection_TopToBottom", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Дети под родителями.
+        /// </summary>
+        public static string Admin_Config_TreeDirection_TopToBottomDescription {
+            get {
+                return ResourceManager.GetString("Admin_Config_TreeDirection_TopToBottomDescription", resourceCulture);
             }
         }
         
@@ -795,6 +867,33 @@ namespace Bonsai.Localization {
         public static string Admin_Config_TreeKinds_FullTreeDescription {
             get {
                 return ResourceManager.GetString("Admin_Config_TreeKinds_FullTreeDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Вид.
+        /// </summary>
+        public static string Admin_Config_TreeView {
+            get {
+                return ResourceManager.GetString("Admin_Config_TreeView", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Компактный.
+        /// </summary>
+        public static string Admin_Config_TreeView_Compact {
+            get {
+                return ResourceManager.GetString("Admin_Config_TreeView_Compact", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Обычный.
+        /// </summary>
+        public static string Admin_Config_TreeView_Default {
+            get {
+                return ResourceManager.GetString("Admin_Config_TreeView_Default", resourceCulture);
             }
         }
         

--- a/src/Bonsai/Localization/Texts.Designer.cs
+++ b/src/Bonsai/Localization/Texts.Designer.cs
@@ -763,29 +763,11 @@ namespace Bonsai.Localization {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Быстро и грубо.
-        /// </summary>
-        public static string Admin_Config_TreeDisplay_FastAndRough {
-            get {
-                return ResourceManager.GetString("Admin_Config_TreeDisplay_FastAndRough", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Не показывать черную ленту на карточках умерших.
         /// </summary>
         public static string Admin_Config_TreeDisplay_HideBlackRibbon {
             get {
                 return ResourceManager.GetString("Admin_Config_TreeDisplay_HideBlackRibbon", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Долго и тщательно.
-        /// </summary>
-        public static string Admin_Config_TreeDisplay_SlowAndThorough {
-            get {
-                return ResourceManager.GetString("Admin_Config_TreeDisplay_SlowAndThorough", resourceCulture);
             }
         }
         
@@ -1137,15 +1119,6 @@ namespace Bonsai.Localization {
         public static string Admin_DemoMode_Banner {
             get {
                 return ResourceManager.GetString("Admin_DemoMode_Banner", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Значение должно быть в диапазоне от 1 до 100.
-        /// </summary>
-        public static string Admin_DynamicConfig_Validation_ThoroughnessRange {
-            get {
-                return ResourceManager.GetString("Admin_DynamicConfig_Validation_ThoroughnessRange", resourceCulture);
             }
         }
         

--- a/src/Bonsai/Localization/Texts.en-us.resx
+++ b/src/Bonsai/Localization/Texts.en-us.resx
@@ -1668,14 +1668,8 @@
   <data name="Admin_Config_TreeDisplay" xml:space="preserve">
     <value>Tree display</value>
   </data>
-  <data name="Admin_Config_TreeDisplay_FastAndRough" xml:space="preserve">
-    <value>Fast and rough</value>
-  </data>
   <data name="Admin_Config_TreeDisplay_HideBlackRibbon" xml:space="preserve">
     <value>Hide black ribbon on the cards of deceased people</value>
-  </data>
-  <data name="Admin_Config_TreeDisplay_SlowAndThorough" xml:space="preserve">
-    <value>Slow and thorough</value>
   </data>
   <data name="Admin_Config_TreeKinds" xml:space="preserve">
     <value>Tree kinds</value>
@@ -2296,9 +2290,6 @@
   </data>
   <data name="Admin_DynamicConfig_Validation_TitleTooLong" xml:space="preserve">
     <value>Caption length cannot exceed 200 characters</value>
-  </data>
-  <data name="Admin_DynamicConfig_Validation_ThoroughnessRange" xml:space="preserve">
-    <value>Value must be between 1 and 100</value>
   </data>
   <data name="Admin_Pages_Validation_TitleEmpty" xml:space="preserve">
     <value>Please enter the page title</value>

--- a/src/Bonsai/Localization/Texts.en-us.resx
+++ b/src/Bonsai/Localization/Texts.en-us.resx
@@ -1629,6 +1629,9 @@
   <data name="Admin_Config_CaptionDescription" xml:space="preserve">
     <value>Displayed in the header</value>
   </data>
+  <data name="Admin_Config_Other" xml:space="preserve">
+    <value>Other</value>
+  </data>
   <data name="Admin_Config_Registration" xml:space="preserve">
     <value>Registration</value>
   </data>
@@ -1638,8 +1641,29 @@
   <data name="Admin_Config_Registration_Enabled" xml:space="preserve">
     <value>Allowed</value>
   </data>
+  <data name="Admin_Config_Section_Main" xml:space="preserve">
+    <value>General</value>
+  </data>
+  <data name="Admin_Config_Section_Tree" xml:space="preserve">
+    <value>Family tree</value>
+  </data>
   <data name="Admin_Config_Title" xml:space="preserve">
     <value>Settings</value>
+  </data>
+  <data name="Admin_Config_TreeDirection" xml:space="preserve">
+    <value>Direction</value>
+  </data>
+  <data name="Admin_Config_TreeDirection_BottomToTop" xml:space="preserve">
+    <value>Bottom to top</value>
+  </data>
+  <data name="Admin_Config_TreeDirection_BottomToTopDescription" xml:space="preserve">
+    <value>Children above their parents</value>
+  </data>
+  <data name="Admin_Config_TreeDirection_TopToBottom" xml:space="preserve">
+    <value>Top to bottom</value>
+  </data>
+  <data name="Admin_Config_TreeDirection_TopToBottomDescription" xml:space="preserve">
+    <value>Children below their parents</value>
   </data>
   <data name="Admin_Config_TreeDisplay" xml:space="preserve">
     <value>Tree display</value>
@@ -1679,6 +1703,15 @@
   </data>
   <data name="Admin_Config_TreeKinds_FullTreeDescription" xml:space="preserve">
     <value>the whole connected graph of relatives</value>
+  </data>
+  <data name="Admin_Config_TreeView" xml:space="preserve">
+    <value>View</value>
+  </data>
+  <data name="Admin_Config_TreeView_Compact" xml:space="preserve">
+    <value>Compact</value>
+  </data>
+  <data name="Admin_Config_TreeView_Default" xml:space="preserve">
+    <value>Default</value>
   </data>
   <data name="Admin_Config_Version" xml:space="preserve">
     <value>Version</value>

--- a/src/Bonsai/Localization/Texts.resx
+++ b/src/Bonsai/Localization/Texts.resx
@@ -1682,14 +1682,8 @@
   <data name="Admin_Config_TreeDisplay" xml:space="preserve">
     <value>Внешний вид дерева</value>
   </data>
-  <data name="Admin_Config_TreeDisplay_FastAndRough" xml:space="preserve">
-    <value>Быстро и грубо</value>
-  </data>
   <data name="Admin_Config_TreeDisplay_HideBlackRibbon" xml:space="preserve">
     <value>Не показывать черную ленту на карточках умерших</value>
-  </data>
-  <data name="Admin_Config_TreeDisplay_SlowAndThorough" xml:space="preserve">
-    <value>Долго и тщательно</value>
   </data>
   <data name="Admin_Config_TreeKinds" xml:space="preserve">
     <value>Типы деревьев</value>
@@ -2331,9 +2325,6 @@
   </data>
   <data name="Admin_DynamicConfig_Validation_TitleTooLong" xml:space="preserve">
     <value>Название не может превышать 200 символов</value>
-  </data>
-  <data name="Admin_DynamicConfig_Validation_ThoroughnessRange" xml:space="preserve">
-    <value>Значение должно быть в диапазоне от 1 до 100</value>
   </data>
   <data name="Admin_Pages_Validation_TitleEmpty" xml:space="preserve">
     <value>Необходимо ввести название страницы</value>

--- a/src/Bonsai/Localization/Texts.resx
+++ b/src/Bonsai/Localization/Texts.resx
@@ -1643,6 +1643,9 @@
   <data name="Admin_Config_CaptionDescription" xml:space="preserve">
     <value>Показывается в заголовке сайта</value>
   </data>
+  <data name="Admin_Config_Other" xml:space="preserve">
+    <value>Прочее</value>
+  </data>
   <data name="Admin_Config_Registration" xml:space="preserve">
     <value>Регистрация</value>
   </data>
@@ -1652,8 +1655,29 @@
   <data name="Admin_Config_Registration_Enabled" xml:space="preserve">
     <value>Разрешена</value>
   </data>
+  <data name="Admin_Config_Section_Main" xml:space="preserve">
+    <value>Главное</value>
+  </data>
+  <data name="Admin_Config_Section_Tree" xml:space="preserve">
+    <value>Фамильное древо</value>
+  </data>
   <data name="Admin_Config_Title" xml:space="preserve">
     <value>Настройки</value>
+  </data>
+  <data name="Admin_Config_TreeDirection" xml:space="preserve">
+    <value>Направление</value>
+  </data>
+  <data name="Admin_Config_TreeDirection_BottomToTop" xml:space="preserve">
+    <value>Снизу вверх</value>
+  </data>
+  <data name="Admin_Config_TreeDirection_BottomToTopDescription" xml:space="preserve">
+    <value>Дети над родителями</value>
+  </data>
+  <data name="Admin_Config_TreeDirection_TopToBottom" xml:space="preserve">
+    <value>Сверху вниз</value>
+  </data>
+  <data name="Admin_Config_TreeDirection_TopToBottomDescription" xml:space="preserve">
+    <value>Дети под родителями</value>
   </data>
   <data name="Admin_Config_TreeDisplay" xml:space="preserve">
     <value>Внешний вид дерева</value>
@@ -1693,6 +1717,15 @@
   </data>
   <data name="Admin_Config_TreeKinds_FullTreeDescription" xml:space="preserve">
     <value>весь связанный граф родственников</value>
+  </data>
+  <data name="Admin_Config_TreeView" xml:space="preserve">
+    <value>Вид</value>
+  </data>
+  <data name="Admin_Config_TreeView_Compact" xml:space="preserve">
+    <value>Компактный</value>
+  </data>
+  <data name="Admin_Config_TreeView_Default" xml:space="preserve">
+    <value>Обычный</value>
   </data>
   <data name="Admin_Config_Version" xml:space="preserve">
     <value>Версия</value>

--- a/src/Bonsai/package-lock.json
+++ b/src/Bonsai/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@viz-js/viz": "^3.30.0",
         "blueimp-file-upload": "10.32.0",
         "bootstrap": "4.6.1",
         "datepicker-bootstrap": "1.9.13",
@@ -1455,12 +1454,6 @@
       "dependencies": {
         "@types/estree": "*"
       }
-    },
-    "node_modules/@viz-js/viz": {
-      "version": "3.30.0",
-      "resolved": "https://registry.npmjs.org/@viz-js/viz/-/viz-3.30.0.tgz",
-      "integrity": "sha512-2zmcP55QY44uQfZ+GvgNHmGd8S6KUD+2eMur9AbYybSzrOd/m8nMUg0ZircJNiJRKGgVBKAE8kh0hAwpUFUFQQ==",
-      "license": "MIT"
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
@@ -4422,11 +4415,6 @@
       "requires": {
         "@types/estree": "*"
       }
-    },
-    "@viz-js/viz": {
-      "version": "3.30.0",
-      "resolved": "https://registry.npmjs.org/@viz-js/viz/-/viz-3.30.0.tgz",
-      "integrity": "sha512-2zmcP55QY44uQfZ+GvgNHmGd8S6KUD+2eMur9AbYybSzrOd/m8nMUg0ZircJNiJRKGgVBKAE8kh0hAwpUFUFQQ=="
     },
     "abbrev": {
       "version": "1.1.1",

--- a/src/Bonsai/package-lock.json
+++ b/src/Bonsai/package-lock.json
@@ -9,12 +9,12 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@viz-js/viz": "^3.30.0",
         "blueimp-file-upload": "10.32.0",
         "bootstrap": "4.6.1",
         "datepicker-bootstrap": "1.9.13",
         "devbridge-autocomplete": "1.4.10",
         "easymde": "2.15.0",
-        "elkjs": "0.8.2",
         "font-awesome": "4.7.0",
         "gijgo": "1.9.13",
         "jquery": "3.6.0",
@@ -1456,6 +1456,12 @@
         "@types/estree": "*"
       }
     },
+    "node_modules/@viz-js/viz": {
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@viz-js/viz/-/viz-3.30.0.tgz",
+      "integrity": "sha512-2zmcP55QY44uQfZ+GvgNHmGd8S6KUD+2eMur9AbYybSzrOd/m8nMUg0ZircJNiJRKGgVBKAE8kh0hAwpUFUFQQ==",
+      "license": "MIT"
+    },
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -1855,11 +1861,6 @@
         "codemirror-spell-checker": "1.1.2",
         "marked": "^2.0.3"
       }
-    },
-    "node_modules/elkjs": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.8.2.tgz",
-      "integrity": "sha512-L6uRgvZTH+4OF5NE/MBbzQx/WYpru1xCBE9respNj6qznEewGUIfhzmm7horWWxbNO2M0WckQypGctR8lH79xQ=="
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -4422,6 +4423,11 @@
         "@types/estree": "*"
       }
     },
+    "@viz-js/viz": {
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@viz-js/viz/-/viz-3.30.0.tgz",
+      "integrity": "sha512-2zmcP55QY44uQfZ+GvgNHmGd8S6KUD+2eMur9AbYybSzrOd/m8nMUg0ZircJNiJRKGgVBKAE8kh0hAwpUFUFQQ=="
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -4722,11 +4728,6 @@
         "codemirror-spell-checker": "1.1.2",
         "marked": "^2.0.3"
       }
-    },
-    "elkjs": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.8.2.tgz",
-      "integrity": "sha512-L6uRgvZTH+4OF5NE/MBbzQx/WYpru1xCBE9respNj6qznEewGUIfhzmm7horWWxbNO2M0WckQypGctR8lH79xQ=="
     },
     "emoji-regex": {
       "version": "8.0.0",

--- a/src/Bonsai/package.json
+++ b/src/Bonsai/package.json
@@ -24,7 +24,6 @@
     "vite-plugin-static-copy": "^2.2.0"
   },
   "dependencies": {
-    "@viz-js/viz": "^3.30.0",
     "blueimp-file-upload": "10.32.0",
     "bootstrap": "4.6.1",
     "datepicker-bootstrap": "1.9.13",

--- a/src/Bonsai/package.json
+++ b/src/Bonsai/package.json
@@ -24,12 +24,12 @@
     "vite-plugin-static-copy": "^2.2.0"
   },
   "dependencies": {
+    "@viz-js/viz": "^3.30.0",
     "blueimp-file-upload": "10.32.0",
     "bootstrap": "4.6.1",
     "datepicker-bootstrap": "1.9.13",
     "devbridge-autocomplete": "1.4.10",
     "easymde": "2.15.0",
-    "elkjs": "0.8.2",
     "font-awesome": "4.7.0",
     "gijgo": "1.9.13",
     "jquery": "3.6.0",

--- a/src/Bonsai/vite.config.js
+++ b/src/Bonsai/vite.config.js
@@ -174,15 +174,9 @@ export default defineConfig(({ mode }) => ({
                 { src: 'node_modules/font-awesome/fonts/*', dest: 'fonts' },
                 { src: 'node_modules/gijgo/fonts/*', dest: 'fonts' },
                 { src: 'Areas/Common/Fonts/*', dest: 'fonts' },
-                // ELK tree layout files (go to project root External/, not wwwroot/External/)
+                // Graphviz tree layout files (go to project root External/, not wwwroot/External/)
                 { src: 'Areas/Admin/BackendScripts/tree-layout.js', dest: '../../External/tree' },
-                { src: 'node_modules/elkjs/lib/elk-api.js', dest: '../../External/tree' },
-                { src: 'node_modules/elkjs/lib/elk-worker.min.js', dest: '../../External/tree' },
-                {
-                    src: 'node_modules/elkjs/lib/main.js',
-                    dest: '../../External/tree',
-                    rename: 'elk.js'
-                },
+                { src: 'node_modules/@viz-js/viz/dist/viz.cjs', dest: '../../External/tree' },
                 // PDF.js worker (named to match vendor-admin.js bundle)
                 {
                     src: 'node_modules/pdfjs-dist/build/pdf.worker.js',

--- a/src/Bonsai/vite.config.js
+++ b/src/Bonsai/vite.config.js
@@ -174,9 +174,6 @@ export default defineConfig(({ mode }) => ({
                 { src: 'node_modules/font-awesome/fonts/*', dest: 'fonts' },
                 { src: 'node_modules/gijgo/fonts/*', dest: 'fonts' },
                 { src: 'Areas/Common/Fonts/*', dest: 'fonts' },
-                // Graphviz tree layout files (go to project root External/, not wwwroot/External/)
-                { src: 'Areas/Admin/BackendScripts/tree-layout.js', dest: '../../External/tree' },
-                { src: 'node_modules/@viz-js/viz/dist/viz.cjs', dest: '../../External/tree' },
                 // PDF.js worker (named to match vendor-admin.js bundle)
                 {
                     src: 'node_modules/pdfjs-dist/build/pdf.worker.js',


### PR DESCRIPTION
Значительные улучшения для отображения дерева:
* Вместо ELK.js используется Graphviz:
    * Граф гораздо чище выглядит даже на сотне элементов
    * Вычисляется в десятки раз быстрее
    * Больше не нужен рантайм NodeJS в образе - размер уменьшился
* Дополнительные настройки дерева:
    * Направление: сверху вниз (как сейчас) или снизу вверх
    * Вид: обычный (как сейчас) или компактный (маленькие карточки с инициалами)